### PR TITLE
Add dynamic unit system (incl. Unit toggle #78)

### DIFF
--- a/docs/unit-conventions.md
+++ b/docs/unit-conventions.md
@@ -1,0 +1,323 @@
+# Unit Conventions Reference
+
+This document provides a comprehensive overview of all variable types used in the Berkeley Decarb Tool, their internal storage units, and display units for SI and IP systems.
+
+**Ground Rule**: All calculations use base SI units internally. Unit conversion is applied only for display purposes.
+
+---
+
+## Implementation Overview
+
+The centralized unit conversion system is implemented in `utils/units.py` with:
+
+1. **`UNIT_MAP`**: Category-based unit definitions with `base`, `SI`, and `IP` configurations
+2. **`COLUMN_REGISTRY`**: Explicit mapping of column names to their unit categories
+3. **`COLUMN_DISPLAY_NAMES`**: Human-readable labels for columns
+4. **Helper Functions**: `convert_dataframe()`, `convert_value()`, `get_display_unit()`, etc.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    utils/units.py                                │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐  │
+│  │   UNIT_MAP      │  │ COLUMN_REGISTRY │  │  Helper Funcs   │  │
+│  │  (categories)   │  │ (col → category)│  │                 │  │
+│  │                 │  │                 │  │ convert_value() │  │
+│  │ energy:         │  │ elec_Wh: energy │  │ convert_df()    │  │
+│  │   base: Wh      │  │ chw_W: power_c  │  │ get_display_unit│  │
+│  │   SI: kWh       │  │ t_out_C: temp   │  │ format_value()  │  │
+│  │   IP: BTU       │  │ ...             │  │                 │  │
+│  └─────────────────┘  └─────────────────┘  └─────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Summary: Unit Toggle Implementation Status
+
+| Status | Description |
+|--------|-------------|
+| ✅ | Implemented in `UNIT_MAP` and `COLUMN_REGISTRY` |
+| ⚠️ | Partially implemented or inconsistent |
+| ❌ | Not implemented |
+| N/A | No conversion needed (dimensionless) |
+
+---
+
+## 1. Energy Variables
+
+| Variable | Column/Field | Internal Unit | SI Display | IP Display | Status |
+|----------|--------------|---------------|------------|------------|--------|
+| Total electricity | `elec_Wh` | Wh | kWh | BTU | ✅ |
+| Total gas | `gas_Wh` | Wh | kWh | BTU | ✅ |
+| HR-WWHP electricity | `elec_hr_Wh` | Wh | kWh | BTU | ✅ |
+| AWHP heating elec | `elec_awhp_h_Wh` | Wh | kWh | BTU | ✅ |
+| AWHP cooling elec | `elec_awhp_c_Wh` | Wh | kWh | BTU | ✅ |
+| Resistance heater elec | `elec_res_Wh` | Wh | kWh | BTU | ✅ |
+| Chiller electricity | `elec_chiller_Wh` | Wh | kWh | BTU | ✅ |
+| Boiler gas | `gas_boiler_Wh` | Wh | kWh | BTU | ✅ |
+
+---
+
+## 2. Power / Load Variables
+
+**Note**: Heating power uses BTU/h in IP mode. Cooling power uses TR (tons of refrigeration) in IP mode.
+
+| Variable | Column/Field | Internal Unit | SI Display | IP Display | Status |
+|----------|--------------|---------------|------------|------------|--------|
+| Heating load | `heating_W` | W | kW | BTU/h | ✅ |
+| Cooling load | `cooling_W` | W | kW | TR | ✅ |
+| HHW load | `hhw_W` | W | kW | BTU/h | ✅ |
+| CHW load | `chw_W` | W | kW | TR | ✅ |
+| Peak HHW load | `hhw_max_load` | W | kW | BTU/h | ✅ |
+| Peak CHW load | `chw_max_load` | W | kW | TR | ✅ |
+| Mean HHW load | `hhw_mean_load` | W | kW | BTU/h | ✅ |
+| Mean CHW load | `chw_mean_load` | W | kW | TR | ✅ |
+| Median HHW load | `hhw_median_load` | W | kW | BTU/h | ✅ |
+| Median CHW load | `chw_median_load` | W | kW | TR | ✅ |
+| Min HHW load | `hhw_min_load` | W | kW | BTU/h | ✅ |
+| Min CHW load | `chw_min_load` | W | kW | TR | ✅ |
+| Q25/Q75 HHW load | `hhw_q25_load`, `hhw_q75_load` | W | kW | BTU/h | ✅ |
+| Q25/Q75 CHW load | `chw_q25_load`, `chw_q75_load` | W | kW | TR | ✅ |
+| HR heating output | `hr_hhw_W` | W | kW | BTU/h | ✅ |
+| HR cooling output | `hr_chw_W` | W | kW | TR | ✅ |
+| AWHP heating output | `awhp_hhw_W` | W | kW | BTU/h | ✅ |
+| AWHP cooling output | `awhp_chw_W` | W | kW | TR | ✅ |
+| Boiler heating output | `boiler_hhw_W` | W | kW | BTU/h | ✅ |
+| Chiller cooling output | `chiller_chw_W` | W | kW | TR | ✅ |
+| Resistance heater output | `res_hhw_W` | W | kW | BTU/h | ✅ |
+| HHW remaining | `hhw_rem_W` | W | kW | BTU/h | ✅ |
+| CHW remaining | `chw_rem_W` | W | kW | TR | ✅ |
+
+---
+
+## 3. Capacity Variables
+
+| Variable | Column/Field | Internal Unit | SI Display | IP Display | Status |
+|----------|--------------|---------------|------------|------------|--------|
+| HR max heating cap | `max_cap_h_hr_W` | W | kW | BTU/h | ✅ |
+| HR min heating cap | `min_cap_h_hr_W` | W | kW | BTU/h | ✅ |
+| Simultaneous HR cap | `simult_h_hr_W` | W | kW | BTU/h | ✅ |
+| AWHP heating capacity | `awhp_cap_h_W` | W | kW | BTU/h | ✅ |
+| AWHP cooling capacity | `awhp_cap_c_W` | W | kW | TR | ✅ |
+| Equipment rated capacity | `capacity_W` | W | kW | BTU/h | ✅ |
+
+---
+
+## 4. Temperature Variables
+
+| Variable | Column/Field | Internal Unit | SI Display | IP Display | Status |
+|----------|--------------|---------------|------------|------------|--------|
+| Outdoor air temp | `t_out_C` | °C | °C | °F | ✅ |
+| Max outdoor temp | `max_temp` | °C | °C | °F | ✅ |
+| Min outdoor temp | `min_temp` | °C | °C | °F | ✅ |
+| Median outdoor temp | `median_temp` | °C | °C | °F | ✅ |
+
+---
+
+## 5. Area Variables
+
+| Variable | Column/Field | Internal Unit | SI Display | IP Display | Status |
+|----------|--------------|---------------|------------|------------|--------|
+| Building floor area | `area_sqm` | m² | m² | ft² | ✅ |
+
+---
+
+## 6. Load Intensity Variables
+
+| Variable | Column/Field | Internal Unit | SI Display | IP Display | Status |
+|----------|--------------|---------------|------------|------------|--------|
+| Peak HHW per area | `hhw_max_load_per_area` | W/m² | W/m² | BTU/h·ft² | ✅ |
+| Peak CHW per area | `chw_max_load_per_area` | W/m² | W/m² | BTU/h·ft² | ✅ |
+
+---
+
+## 7. Emissions Variables
+
+| Variable | Column/Field | Internal Unit | SI Display | IP Display | Status |
+|----------|--------------|---------------|------------|------------|--------|
+| Electricity emissions | `elec_emissions` | kg CO₂e | kg CO₂e | lb CO₂e | ✅ |
+| Gas emissions | `gas_emissions` | kg CO₂e | kg CO₂e | lb CO₂e | ✅ |
+| Refrigerant emissions | `total_refrig_emissions` | kg CO₂e | kg CO₂e | lb CO₂e | ✅ |
+| Total emissions | `total_emissions` | kg CO₂e | kg CO₂e | lb CO₂e | ✅ |
+| Total refrigerant GWP | `total_refrig_gwp_kg` | kg CO₂e | kg CO₂e | lb CO₂e | ✅ |
+
+---
+
+## 8. Emission Rate Variables
+
+| Variable | Column/Field | Internal Unit | SI Display | IP Display | Status |
+|----------|--------------|---------------|------------|------------|--------|
+| Electricity emission rate | `elec_emissions_rate_gCO2e_per_kWh` | g CO₂e/kWh | g CO₂e/kWh | lb CO₂e/kBTU | ✅ |
+| LRMER combustion | `lrmer_co2e_c` | g CO₂e/kWh | g CO₂e/kWh | lb CO₂e/kBTU | ✅ |
+| LRMER pre-combustion | `lrmer_co2e_p` | g CO₂e/kWh | g CO₂e/kWh | lb CO₂e/kBTU | ✅ |
+| SRMER combustion | `srmer_co2e_c` | g CO₂e/kWh | g CO₂e/kWh | lb CO₂e/kBTU | ✅ |
+| SRMER pre-combustion | `srmer_co2e_p` | g CO₂e/kWh | g CO₂e/kWh | lb CO₂e/kBTU | ✅ |
+| NG leakage rate | `annual_ng_leakage_g_per_kWh` | g/kWh | g/kWh | lb/kBTU | ✅ |
+
+---
+
+## 9. Refrigerant Variables
+
+| Variable | Column/Field | Internal Unit | SI Display | IP Display | Status |
+|----------|--------------|---------------|------------|------------|--------|
+| HR-WWHP refrigerant weight | `hr_wwhp_refrigerant_weight_kg` | kg | kg | lb | ✅ |
+| AWHP refrigerant weight | `total_awhp_refrigerant_weight_kg` | kg | kg | lb | ✅ |
+| Chiller refrigerant weight | `chiller_refrigerant_weight_kg` | kg | kg | lb | ✅ |
+| Equipment refrigerant charge | `refrigerant_weight_g` | g | kg | lb | ✅ |
+| HR-WWHP refrigerant GWP | `hr_wwhp_refrigerant_gwp_kgCO2e_per_kgRefrig` | kg CO₂e/kg | kg CO₂e/kg | lb CO₂e/lb | ✅ |
+| AWHP refrigerant GWP | `total_awhp_refrigerant_gwp_kgCO2e_per_kgRefrig` | kg CO₂e/kg | kg CO₂e/kg | lb CO₂e/lb | ✅ |
+| Chiller refrigerant GWP | `chiller_refrigerant_gwp_kgCO2e_per_kgRefrig` | kg CO₂e/kg | kg CO₂e/kg | lb CO₂e/lb | ✅ |
+| Refrigerant leakage rate | `annual_refrig_leakage_percent` | fraction | % | % | N/A |
+
+---
+
+## 10. Efficiency / COP Variables (No Conversion Needed)
+
+| Variable | Column/Field | Internal Unit | Display | Status |
+|----------|--------------|---------------|---------|--------|
+| HR heating COP | `hr_cop_h` | dimensionless | COP | N/A |
+| AWHP heating COP | `awhp_cop_h` | dimensionless | COP | N/A |
+| AWHP cooling COP | `awhp_cop_c` | dimensionless | COP | N/A |
+| Chiller COP | `chiller_cop` | dimensionless | COP | N/A |
+| Boiler efficiency | `boiler_eff` | fraction | % | N/A |
+
+---
+
+## Current `UNIT_MAP` in `utils/units.py`
+
+```python
+UNIT_MAP = {
+    "energy": {
+        "base": "Wh",
+        "SI": {"unit": "kWh", "func": Wh_to_kWh},
+        "IP": {"unit": "BTU", "func": Wh_to_BTUh},
+    },
+    "power": {
+        "base": "W",
+        "SI": {"unit": "kW", "func": W_to_kW},
+        "IP": {"unit": "BTU/h", "func": lambda x: x * W_to_BTUh},
+    },
+    "power_cooling": {
+        "base": "W",
+        "SI": {"unit": "kW", "func": W_to_kW},
+        "IP": {"unit": "TR", "func": W_to_tons},
+    },
+    "capacity": {
+        "base": "W",
+        "SI": {"unit": "kW", "func": W_to_kW},
+        "IP": {"unit": "BTU/h", "func": lambda x: x * W_to_BTUh},
+    },
+    "capacity_cooling": {
+        "base": "W",
+        "SI": {"unit": "kW", "func": W_to_kW},
+        "IP": {"unit": "TR", "func": W_to_tons},
+    },
+    "temperature": {
+        "base": "°C",
+        "SI": {"unit": "°C", "func": lambda x: x},
+        "IP": {"unit": "°F", "func": C_to_F},
+    },
+    "area": {
+        "base": "m²",
+        "SI": {"unit": "m²", "func": lambda x: x},
+        "IP": {"unit": "ft²", "func": sqm_to_sqft},
+    },
+    "emissions": {
+        "base": "kg CO₂e",
+        "SI": {"unit": "kg CO₂e", "func": lambda x: x},
+        "IP": {"unit": "lb CO₂e", "func": kg_to_lbs},
+    },
+    "emissions_rate": {
+        "base": "g CO₂e/kWh",
+        "SI": {"unit": "g CO₂e/kWh", "func": lambda x: x},
+        "IP": {"unit": "lb CO₂e/kBTU", "func": lambda x: x * g_to_lb / Wh_to_BTU},
+    },
+    "mass": {
+        "base": "kg",
+        "SI": {"unit": "kg", "func": lambda x: x},
+        "IP": {"unit": "lb", "func": kg_to_lbs},
+    },
+    "mass_g": {
+        "base": "g",
+        "SI": {"unit": "kg", "func": lambda x: x / 1000},
+        "IP": {"unit": "lb", "func": lambda x: x * g_to_lb},
+    },
+    "load_intensity": {
+        "base": "W/m²",
+        "SI": {"unit": "W/m²", "func": lambda x: x},
+        "IP": {"unit": "BTU/h·ft²", "func": lambda x: x * W_to_BTUh / 10.7639},
+    },
+    "gwp": {
+        "base": "kg CO₂e/kg",
+        "SI": {"unit": "kg CO₂e/kg", "func": lambda x: x},
+        "IP": {"unit": "lb CO₂e/lb", "func": lambda x: x},
+    },
+    # ... additional categories
+}
+```
+
+---
+
+## Key Helper Functions
+
+```python
+# Get category for a column
+category = get_category("elec_Wh")  # Returns "energy"
+
+# Get display unit for category and mode
+unit = get_display_unit("energy", "IP")  # Returns "BTU"
+
+# Convert a single value
+converted = convert_value(1000, "elec_Wh", "SI")  # Returns 1.0 (kWh)
+
+# Convert entire DataFrame
+df_converted = convert_dataframe(df, "IP")
+
+# Get column label with unit
+label = get_column_label("elec_Wh", "SI")  # Returns "Total Electricity [kWh]"
+```
+
+---
+
+## Usage in Components
+
+### Charts (`src/visuals.py`)
+```python
+# Convert DataFrame before plotting
+df = convert_dataframe(df, unit_mode)
+
+# Get hover units
+hover_unit = get_display_unit("energy", unit_mode)
+```
+
+### Tables (`layout/input.py`)
+```python
+def build_building_table(buildings_data, selected_id=None, unit_mode="SI"):
+    # Convert values and get unit labels dynamically
+    unit = get_display_unit(category, unit_mode)
+    value = convert_value(raw_value, column_name, unit_mode)
+```
+
+### Download (`pages/results_page.py`)
+```python
+# Convert DataFrame before export
+df = convert_dataframe(df, unit_mode)
+# Rename columns to include units
+df = df.rename(columns={col: get_column_label(col, unit_mode) for col in df.columns})
+```
+
+---
+
+## Notes
+
+- **COP and efficiency** are dimensionless and don't require unit conversion
+- **Percentages and fractions** are unitless (display as % or 0-1 based on context)
+- **Counts** (number of units, years, etc.) don't require conversion
+- Internal storage always uses **base SI units** (W, Wh, °C, m², kg, g)
+- Display may use derived SI units (kW, kWh) for readability
+- **Cooling power** uses TR (tons of refrigeration) in IP mode
+- **Heating power** uses BTU/h in IP mode
+
+---
+
+*Last updated: 2026-03-12*

--- a/docs/unit-conventions.md
+++ b/docs/unit-conventions.md
@@ -11,23 +11,25 @@ This document provides a comprehensive overview of all variable types used in th
 The centralized unit conversion system is implemented in `utils/units.py` with:
 
 1. **`UNIT_MAP`**: Category-based unit definitions with `base`, `SI`, and `IP` configurations
-2. **`COLUMN_REGISTRY`**: Explicit mapping of column names to their unit categories
-3. **`COLUMN_DISPLAY_NAMES`**: Human-readable labels for columns
-4. **Helper Functions**: `convert_dataframe()`, `convert_value()`, `get_display_unit()`, etc.
+2. **`COLUMN_CONFIG`**: Unified registry mapping column names to `(category, display_name)` tuples
+3. **`AUTO_SCALE_CONFIG`**: Automatic scaling for large values (e.g., kWh → MWh → GWh)
+4. **Helper Functions**: `convert_dataframe()`, `convert_value()`, `get_auto_scale()`, etc.
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                    utils/units.py                                │
-│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐  │
-│  │   UNIT_MAP      │  │ COLUMN_REGISTRY │  │  Helper Funcs   │  │
-│  │  (categories)   │  │ (col → category)│  │                 │  │
-│  │                 │  │                 │  │ convert_value() │  │
-│  │ energy:         │  │ elec_Wh: energy │  │ convert_df()    │  │
-│  │   base: Wh      │  │ chw_W: power_c  │  │ get_display_unit│  │
-│  │   SI: kWh       │  │ t_out_C: temp   │  │ format_value()  │  │
-│  │   IP: BTU       │  │ ...             │  │                 │  │
-│  └─────────────────┘  └─────────────────┘  └─────────────────┘  │
-└─────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│                         utils/units.py                               │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌──────────────────────┐  │
+│  │   UNIT_MAP      │  │  COLUMN_CONFIG  │  │  AUTO_SCALE_CONFIG   │  │
+│  │  (categories)   │  │ (col → category │  │  (large value        │  │
+│  │                 │  │  + display name)│  │   scaling)           │  │
+│  │ energy:         │  │                 │  │                      │  │
+│  │   base: Wh      │  │ elec_Wh:        │  │ energy:              │  │
+│  │   SI: kWh       │  │  (energy,       │  │   SI: kWh→MWh→GWh    │  │
+│  │   IP: BTU       │  │   "Total Elec") │  │   IP: kBTU→MMBTU     │  │
+│  └─────────────────┘  └─────────────────┘  └──────────────────────┘  │
+│                                                                      │
+│  Derived views (backward compat): COLUMN_REGISTRY, COLUMN_DISPLAY_NAMES
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -187,73 +189,47 @@ The centralized unit conversion system is implemented in `utils/units.py` with:
 
 ```python
 UNIT_MAP = {
+    "energy":          {"base": "Wh",  "SI": "kWh",       "IP": "BTU"},
+    "power":           {"base": "W",   "SI": "kW",        "IP": "BTU/h"},
+    "power_cooling":   {"base": "W",   "SI": "kW",        "IP": "TR"},
+    "capacity":        {"base": "W",   "SI": "kW",        "IP": "BTU/h"},
+    "capacity_cooling":{"base": "W",   "SI": "kW",        "IP": "TR"},
+    "temperature":     {"base": "°C",  "SI": "°C",        "IP": "°F"},
+    "area":            {"base": "m²",  "SI": "m²",        "IP": "ft²"},
+    "emissions":       {"base": "kg",  "SI": "kg CO₂e",   "IP": "lb CO₂e"},
+    "emissions_rate":  {"base": "g/kWh", "SI": "g CO₂e/kWh", "IP": "lb CO₂e/kBTU"},
+    "ng_leakage_rate": {"base": "g/kWh", "SI": "g/kWh",   "IP": "lb/kBTU"},
+    "gas_emission_factor": {"base": "g/kWh", "SI": "g CO₂e/kWh", "IP": "lb CO₂e/kBTU"},
+    "mass":            {"base": "kg",  "SI": "kg",        "IP": "lb"},
+    "mass_g":          {"base": "g",   "SI": "kg",        "IP": "lb"},
+    "load_intensity":  {"base": "W/m²", "SI": "W/m²",     "IP": "BTU/h·ft²"},
+    "gwp":             {"base": "kg/kg", "SI": "kg CO₂e/kg", "IP": "lb CO₂e/lb"},
+}
+```
+
+## Current `AUTO_SCALE_CONFIG` in `utils/units.py`
+
+```python
+AUTO_SCALE_CONFIG = {
     "energy": {
-        "base": "Wh",
-        "SI": {"unit": "kWh", "func": Wh_to_kWh},
-        "IP": {"unit": "BTU", "func": Wh_to_BTUh},
+        "SI": [(1e9, "GWh"), (1e6, "MWh"), (1e3, "kWh")],
+        "IP": [(1e6/3.412, "MMBTU"), (1e3/3.412, "kBTU")],
     },
     "power": {
-        "base": "W",
-        "SI": {"unit": "kW", "func": W_to_kW},
-        "IP": {"unit": "BTU/h", "func": lambda x: x * W_to_BTUh},
+        "SI": [(1e6, "MW"), (1e3, "kW")],
+        "IP": [(1e6/3.412, "MMBTU/h"), (1e3/3.412, "kBTU/h")],
     },
     "power_cooling": {
-        "base": "W",
-        "SI": {"unit": "kW", "func": W_to_kW},
-        "IP": {"unit": "TR", "func": W_to_tons},
-    },
-    "capacity": {
-        "base": "W",
-        "SI": {"unit": "kW", "func": W_to_kW},
-        "IP": {"unit": "BTU/h", "func": lambda x: x * W_to_BTUh},
-    },
-    "capacity_cooling": {
-        "base": "W",
-        "SI": {"unit": "kW", "func": W_to_kW},
-        "IP": {"unit": "TR", "func": W_to_tons},
-    },
-    "temperature": {
-        "base": "°C",
-        "SI": {"unit": "°C", "func": lambda x: x},
-        "IP": {"unit": "°F", "func": C_to_F},
-    },
-    "area": {
-        "base": "m²",
-        "SI": {"unit": "m²", "func": lambda x: x},
-        "IP": {"unit": "ft²", "func": sqm_to_sqft},
+        "SI": [(1e6, "MW"), (1e3, "kW")],
+        "IP": [(3517, "TR")],  # No kTR - stays in TR
     },
     "emissions": {
-        "base": "kg CO₂e",
-        "SI": {"unit": "kg CO₂e", "func": lambda x: x},
-        "IP": {"unit": "lb CO₂e", "func": kg_to_lbs},
+        "SI": [(1e6, "kt CO₂e"), (1e3, "t CO₂e")],
+        "IP": [(1e3, "t CO₂e")],  # EPA convention: metric tons
     },
-    "emissions_rate": {
-        "base": "g CO₂e/kWh",
-        "SI": {"unit": "g CO₂e/kWh", "func": lambda x: x},
-        "IP": {"unit": "lb CO₂e/kBTU", "func": lambda x: x * g_to_lb / Wh_to_BTU},
-    },
-    "mass": {
-        "base": "kg",
-        "SI": {"unit": "kg", "func": lambda x: x},
-        "IP": {"unit": "lb", "func": kg_to_lbs},
-    },
-    "mass_g": {
-        "base": "g",
-        "SI": {"unit": "kg", "func": lambda x: x / 1000},
-        "IP": {"unit": "lb", "func": lambda x: x * g_to_lb},
-    },
-    "load_intensity": {
-        "base": "W/m²",
-        "SI": {"unit": "W/m²", "func": lambda x: x},
-        "IP": {"unit": "BTU/h·ft²", "func": lambda x: x * W_to_BTUh / 10.7639},
-    },
-    "gwp": {
-        "base": "kg CO₂e/kg",
-        "SI": {"unit": "kg CO₂e/kg", "func": lambda x: x},
-        "IP": {"unit": "lb CO₂e/lb", "func": lambda x: x},
-    },
-    # ... additional categories
 }
+# Thresholds are in BASE units (W, Wh, kg)
+# Format: (threshold, unit_label)
 ```
 
 ---
@@ -308,6 +284,52 @@ df = df.rename(columns={col: get_column_label(col, unit_mode) for col in df.colu
 
 ---
 
+## Auto-Scaling for Large Values
+
+The `AUTO_SCALE_CONFIG` automatically scales large accumulated values to appropriate display units:
+
+| Category | SI Scaling | IP Scaling |
+|----------|------------|------------|
+| Energy | Wh → kWh → MWh → GWh | Wh → kBTU → MMBTU |
+| Power (heating) | W → kW → MW | W → kBTU/h → MMBTU/h |
+| Power (cooling) | W → kW → MW | W → TR (no kTR) |
+| Emissions | kg → t CO₂e → kt CO₂e | kg → t CO₂e (metric tons, EPA convention) |
+
+### Usage
+
+```python
+from utils.units import get_auto_scale, format_with_auto_scale
+
+# Get scale factor and unit for a set of values
+scale, unit = get_auto_scale([1500000, 800000], "power", "SI")
+# Returns: (1000, "kW") - values are in the kW range
+
+# Format a single value with auto-scaling
+formatted = format_with_auto_scale(4500000, "power", "SI")
+# Returns: "4,500.0 kW"
+
+# For charts: scale values consistently
+power_scale, power_unit = get_auto_scale(all_values, "power", unit_mode)
+scaled_values = [v / power_scale for v in all_values]
+```
+
+### Load Selection Sliders (IP Mode)
+
+The load selection modal uses appropriate units for IP mode:
+- **Heating (HHW)**: MMBTU/h (avoids extremely large BTU/h values)
+- **Cooling (CHW)**: TR (tons of refrigeration)
+
+---
+
+## Download Export
+
+When exporting data via CSV download:
+- Values are converted to the selected unit mode (SI/IP)
+- Smart rounding is applied: 2 decimal places normally, 3 for values < 1
+- Column headers include units: e.g., "Total Electricity [kWh]"
+
+---
+
 ## Notes
 
 - **COP and efficiency** are dimensionless and don't require unit conversion
@@ -316,8 +338,10 @@ df = df.rename(columns={col: get_column_label(col, unit_mode) for col in df.colu
 - Internal storage always uses **base SI units** (W, Wh, °C, m², kg, g)
 - Display may use derived SI units (kW, kWh) for readability
 - **Cooling power** uses TR (tons of refrigeration) in IP mode
-- **Heating power** uses BTU/h in IP mode
+- **Heating power** uses BTU/h (or MMBTU/h for large values) in IP mode
+- **IP emissions** use metric tons (t CO₂e) per EPA convention, not pounds for large values
+- **IP energy** uses MMBTU (not MBTU) as the standard convention
 
 ---
 
-*Last updated: 2026-03-12*
+*Last updated: 2026-03-13*

--- a/layout/input.py
+++ b/layout/input.py
@@ -212,10 +212,11 @@ def build_building_table(buildings_data, selected_id=None, unit_mode: str = "SI"
 
         body_rows.append(dmc.TableTr(cells))
 
-    # Build header
-    header_cells = [dmc.TableTh("")]  # radio column
+    # Build header (use normal case, not uppercase)
+    header_style = {"textTransform": "none", "fontWeight": 500}
+    header_cells = [dmc.TableTh("", style=header_style)]  # radio column
     header_cells.extend([
-        dmc.TableTh(get_header_label(col, label))
+        dmc.TableTh(get_header_label(col, label), style=header_style)
         for col, label in available_columns
     ])
     header = dmc.TableThead(dmc.TableTr(header_cells))
@@ -1041,8 +1042,9 @@ def build_emissions_table(emission_data, active_ids=None, view_mode="simple", un
             **scen_cell_base,
             **(active_col_style if scen_id in active_ids else inactive_col_style),
         }
-        # Display just the number in the header
-        header_cells.append(dmc.TableTh(str(idx), style=cell_style))
+        # Display capital letter in the header (A, B, C, ...)
+        letter = chr(64 + idx)  # 1 -> 'A', 2 -> 'B', etc.
+        header_cells.append(dmc.TableTh(letter, style=cell_style))
 
     header = dmc.TableThead(dmc.TableTr(header_cells))
 

--- a/layout/input.py
+++ b/layout/input.py
@@ -132,41 +132,92 @@ def select_load_type():
     )
 
 
-def build_building_table(buildings_data, selected_id=None):
+def build_building_table(buildings_data, selected_id=None, unit_mode: str = "SI"):
     """
     Build a table from a DataFrame with predefined columns.
     Only displays columns that exist in the data.
+    Supports unit conversion with auto-scaling via unit_mode ("SI" or "IP").
     """
-    # Define desired columns with their display names
+    from utils.units import (
+        get_category,
+        get_auto_scale_for_values,
+    )
+
+    # Define desired columns with their base display names (without units)
+    # Format: (column_name, display_name)
     column_config = [
         ("location", "Location"),
         ("ashrae_climate_zone", "Climate Zone"),
         ("building_type", "Building Type"),
         ("load_type", "Source"),
-        ("area_sqm", "Area [m²]"),
-        ("hhw_max_load", "Peak HHW Load [W]"),
-        ("chw_max_load", "Peak CHW Load [W]"),
+        ("area_sqm", "Area"),
+        ("hhw_max_load", "Peak HHW Load"),
+        ("chw_max_load", "Peak CHW Load"),
         ("annual_heating_cooling_ratio", "Annual H/C Ratio"),
-        ("min_temp", "Min Temp [°C]"),
-        ("max_temp", "Max Temp [°C]"),
+        ("min_temp", "Min Temp"),
+        ("max_temp", "Max Temp"),
     ]
 
     available_columns = [
         (col, label) for col, label in column_config if col in buildings_data.columns
     ]
 
-    # Build body rows
+    # Pre-calculate auto-scaling for each column
+    # Store (scale_factor, unit_label) for each column
+    column_scales = {}
+    for col, _ in available_columns:
+        category = get_category(col)
+        if category:
+            # Get all non-null values for this column (in base units)
+            values = buildings_data[col].dropna().tolist()
+            if values:
+                scale, unit = get_auto_scale_for_values(values, category, unit_mode)
+                column_scales[col] = (scale, unit)
+
+    # Build header labels with auto-scaled units
+    def get_header_label(col_name: str, base_label: str) -> str:
+        if col_name in column_scales:
+            _, unit = column_scales[col_name]
+            return f"{base_label} [{unit}]"
+        return base_label
+
+    # Build body rows with auto-scaling (directly from base units)
     body_rows = []
     for idx, row in buildings_data.iterrows():
         cells = [
             dmc.TableTd(dmc.Radio(value=str(row.get("building_id", idx))))
         ]  # use 'building_id' field or index
-        cells.extend([dmc.TableTd(str(row[col])) for col, _ in available_columns])
+
+        for col, _ in available_columns:
+            raw_value = row[col]
+            # Scale value if it has a registered category
+            if col in column_scales and raw_value is not None:
+                try:
+                    scale, _ = column_scales[col]
+                    # Divide base unit value by scale to get display value
+                    scaled = float(raw_value) / scale
+                    # Format based on magnitude of scaled value
+                    if abs(scaled) >= 1000:
+                        display_value = f"{scaled:,.0f}"
+                    elif abs(scaled) >= 1:
+                        display_value = f"{scaled:,.1f}"
+                    else:
+                        display_value = f"{scaled:,.2f}"
+                except (TypeError, ValueError):
+                    display_value = str(raw_value)
+            else:
+                display_value = str(raw_value) if raw_value is not None else "—"
+
+            cells.append(dmc.TableTd(display_value))
+
         body_rows.append(dmc.TableTr(cells))
 
     # Build header
     header_cells = [dmc.TableTh("")]  # radio column
-    header_cells.extend([dmc.TableTh(label) for _, label in available_columns])
+    header_cells.extend([
+        dmc.TableTh(get_header_label(col, label))
+        for col, label in available_columns
+    ])
     header = dmc.TableThead(dmc.TableTr(header_cells))
 
     body = dmc.TableTbody(body_rows)
@@ -261,7 +312,12 @@ def modal_load_data_selection(buildings_df: pd.DataFrame):
                             ),
                             dmc.Stack(
                                 [
-                                    dmc.Text("Area (m²)", size="sm", fw=500),
+                                    dmc.Text(
+                                        id="area-slider-label",
+                                        children="Area (m²)",
+                                        size="sm",
+                                        fw=500,
+                                    ),
                                     dmc.RangeSlider(
                                         id="area-range-slider",
                                         min=area_min,
@@ -278,7 +334,12 @@ def modal_load_data_selection(buildings_df: pd.DataFrame):
                             ),
                             dmc.Stack(
                                 [
-                                    dmc.Text("HHW Peak Load [W]", size="sm", fw=500),
+                                    dmc.Text(
+                                        id="hhw-slider-label",
+                                        children="HHW Peak Load [kW]",
+                                        size="sm",
+                                        fw=500,
+                                    ),
                                     dmc.RangeSlider(
                                         id="hhw-range-slider",
                                         min=hhw_min,
@@ -295,7 +356,12 @@ def modal_load_data_selection(buildings_df: pd.DataFrame):
                             ),
                             dmc.Stack(
                                 [
-                                    dmc.Text("CHW Peak Load [W]", size="sm", fw=500),
+                                    dmc.Text(
+                                        id="chw-slider-label",
+                                        children="CHW Peak Load [kW]",
+                                        size="sm",
+                                        fw=500,
+                                    ),
                                     dmc.RangeSlider(
                                         id="chw-range-slider",
                                         min=chw_min,
@@ -1236,11 +1302,21 @@ def edit_emission_modal():
                             max=1,
                             step=0.01,
                         ),
-                        dmc.NumberInput(
-                            id="edit-em-ng-leakage",
-                            label="Annual NG leakage (g/kWh)",
-                            min=0,
-                            step=1,
+                        dmc.Stack(
+                            [
+                                dmc.Text(
+                                    id="edit-em-ng-leakage-label",
+                                    children="Annual NG leakage (g/kWh)",
+                                    size="sm",
+                                    fw=500,
+                                ),
+                                dmc.NumberInput(
+                                    id="edit-em-ng-leakage",
+                                    min=0,
+                                    step=1,
+                                ),
+                            ],
+                            gap=4,
                         ),
                     ],
                 ),

--- a/layout/input.py
+++ b/layout/input.py
@@ -598,7 +598,7 @@ def build_equipment_table(
 
         for idx, scen_id in enumerate(scen_ids):
             raw_value = equipment_df.iloc[idx].get(field, "")
-            display_value = format_table_value(raw_value)
+            display_value = format_table_value(raw_value, field_name=field)
 
             # Build cell style: base + active/inactive + deemphasis + diff highlighting
             cell_style = {
@@ -1027,7 +1027,7 @@ def build_emissions_table(emission_data, active_ids=None, view_mode="simple"):
 
         for idx, scen_id in enumerate(scen_ids):
             raw_value = emission_df.iloc[idx].get(field, "")
-            display_value = format_table_value(raw_value)
+            display_value = format_table_value(raw_value, field_name=field)
 
             # Build cell style: base + active/inactive + deemphasis
             cell_style = {

--- a/layout/input.py
+++ b/layout/input.py
@@ -846,7 +846,7 @@ def edit_equipment_modal():
 # --------------------------------
 
 
-def build_emissions_table(emission_data, active_ids=None, view_mode="simple"):
+def build_emissions_table(emission_data, active_ids=None, view_mode="simple", unit_mode="SI"):
     """
     Transposed emissions scenarios table:
     - Columns = emission scenarios (em_scen_id)
@@ -861,7 +861,10 @@ def build_emissions_table(emission_data, active_ids=None, view_mode="simple"):
         emission_data: Emission scenarios data (list or DataFrame)
         active_ids: Set of scenario IDs that are selected/active
         view_mode: One of "simple", "advanced", or "differences"
+        unit_mode: "SI" or "IP" for unit conversion
     """
+    from utils.units import get_unit_label, get_unit_converter
+
     if isinstance(emission_data, list):
         emission_df = pd.DataFrame(emission_data)
     else:
@@ -881,7 +884,9 @@ def build_emissions_table(emission_data, active_ids=None, view_mode="simple"):
     # Sort for stable column order
     emission_df = emission_df.sort_values("em_scen_id").reset_index(drop=True)
 
-    # Rows to display
+    # Get unit label for NG leakage (dynamic based on unit_mode)
+    ng_leakage_unit = get_unit_label("ng_leakage_rate", unit_mode)
+
     # Rows to display (property name, label)
     # Note: em_scen_id is excluded as it's shown in the header
     row_config = [
@@ -890,7 +895,7 @@ def build_emissions_table(emission_data, active_ids=None, view_mode="simple"):
         ("emission_type", "Emission Type"),
         ("shortrun_weighting", "Short-run weighting"),
         ("annual_refrig_leakage_percent", "Refrigerant leakage (frac)"),
-        ("annual_ng_leakage_g_per_kWh", "NG leakage (g/kWh)"),
+        ("annual_ng_leakage_g_per_kWh", f"NG leakage ({ng_leakage_unit})"),
         ("year", "Year"),
     ]
 
@@ -1015,6 +1020,9 @@ def build_emissions_table(emission_data, active_ids=None, view_mode="simple"):
     # ---------- Property rows ----------
     diff_row_style = TABLE_STYLE.diff_row_style
 
+    # Get converter for NG leakage values
+    ng_leakage_converter = get_unit_converter("ng_leakage_rate", unit_mode)
+
     for field, label in available_rows:
         is_diff_row = field in diff_fields
 
@@ -1027,7 +1035,16 @@ def build_emissions_table(emission_data, active_ids=None, view_mode="simple"):
 
         for idx, scen_id in enumerate(scen_ids):
             raw_value = emission_df.iloc[idx].get(field, "")
-            display_value = format_table_value(raw_value, field_name=field)
+
+            # Apply unit conversion for NG leakage
+            if field == "annual_ng_leakage_g_per_kWh" and raw_value is not None:
+                try:
+                    converted = ng_leakage_converter(float(raw_value))
+                    display_value = f"{converted:.2f}"
+                except (ValueError, TypeError):
+                    display_value = format_table_value(raw_value, field_name=field)
+            else:
+                display_value = format_table_value(raw_value, field_name=field)
 
             # Build cell style: base + active/inactive + deemphasis
             cell_style = {

--- a/layout/output.py
+++ b/layout/output.py
@@ -7,7 +7,7 @@ from dash_iconify import DashIconify
 from src.metadata import Metadata
 
 from src.equipment import EquipmentLibrary, EquipmentScenario
-from utils.units import format_with_units, get_unit_label
+from utils.units import format_with_auto_scale
 
 
 def get_nested_value(obj, attr_path):
@@ -55,11 +55,9 @@ def make_metadata_card(metadata: Metadata, fields, title="", unit_mode="SI"):
 
         # Format value and label based on variable type
         if var_type and value is not None:
-            # Apply unit conversion and formatting
-            display_value = format_with_units(value, var_type, unit_mode)
-            # Append unit to label
-            unit_label = get_unit_label(var_type, unit_mode)
-            label = f"{base_label} [{unit_label}]"
+            # Apply unit conversion with auto-scaling (includes unit in output)
+            display_value = format_with_auto_scale(value, var_type, unit_mode)
+            label = base_label
         else:
             display_value = str(value) if value is not None else "-"
             label = base_label
@@ -97,7 +95,9 @@ def building_characteristics_card(metadata: Metadata, unit_mode="SI"):
         ("base_gea_grid_region", "GEA Grid Region"),
         ("area_sqm", "Building Area", "area"),
     ]
-    return make_metadata_card(metadata, fields, title="Building Characteristics", unit_mode=unit_mode)
+    return make_metadata_card(
+        metadata, fields, title="Building Characteristics", unit_mode=unit_mode
+    )
 
 
 def load_characteristics_card(metadata: Metadata, unit_mode="SI"):
@@ -105,13 +105,15 @@ def load_characteristics_card(metadata: Metadata, unit_mode="SI"):
         ("load_data.load_type", "Load Type"),
         ("load_data.annual_heating_cooling_ratio", "Annual H/C Ratio"),
         ("load_data.hhw_max_load", "Peak Heating Load", "power"),
-        ("load_data.chw_max_load", "Peak Cooling Load", "power"),
+        ("load_data.chw_max_load", "Peak Cooling Load", "power_cooling"),
         ("load_data.max_temp", "Max. Outdoor Temp.", "temperature"),
         ("load_data.median_temp", "Median Outdoor Temp.", "temperature"),
         ("load_data.min_temp", "Min. Outdoor Temp.", "temperature"),
     ]
 
-    return make_metadata_card(metadata, load_fields, title="Load Characteristics", unit_mode=unit_mode)
+    return make_metadata_card(
+        metadata, load_fields, title="Load Characteristics", unit_mode=unit_mode
+    )
 
 
 def summary_equipment_selection(equipment_library: EquipmentLibrary, active_tab=None):
@@ -284,7 +286,11 @@ def summary_project_info(metadata: Metadata, unit_mode="SI"):
         ("area_sqm", "Building Area", "area"),
         # Load-side fields (from LoadData)
         ("load_data.hhw_max_load", "Peak HHW Load", "power"),
-        ("load_data.chw_max_load", "Peak CHW Load", "power"),
+        (
+            "load_data.chw_max_load",
+            "Peak CHW Load",
+            "power_cooling",
+        ),  # Uses TR in IP mode
         ("load_data.annual_heating_cooling_ratio", "Annual Heating/Cooling Ratio"),
     ]
 

--- a/layout/output.py
+++ b/layout/output.py
@@ -7,6 +7,7 @@ from dash_iconify import DashIconify
 from src.metadata import Metadata
 
 from src.equipment import EquipmentLibrary, EquipmentScenario
+from utils.units import format_with_units, get_unit_label
 
 
 def get_nested_value(obj, attr_path):
@@ -30,16 +31,44 @@ def get_nested_value(obj, attr_path):
     return obj
 
 
-def make_metadata_card(metadata: Metadata, fields, title=""):
+def make_metadata_card(metadata: Metadata, fields, title="", unit_mode="SI"):
+    """Build a card displaying metadata fields with optional unit conversion.
+
+    Args:
+        metadata: Object with get_value() method
+        fields: List of tuples. Each tuple can be:
+            - (key, label) for plain text fields
+            - (key, label, var_type) for unit-aware fields (var_type: "power", "area", "temperature")
+        title: Card title
+        unit_mode: "SI" or "IP" for unit conversion
+    """
     rows = []
-    for key, label in fields:
+    for field in fields:
+        # Unpack field definition
+        if len(field) == 3:
+            key, base_label, var_type = field
+        else:
+            key, base_label = field
+            var_type = None
+
         value = metadata.get_value(key)  # ← uses Metadata.get_value
+
+        # Format value and label based on variable type
+        if var_type and value is not None:
+            # Apply unit conversion and formatting
+            display_value = format_with_units(value, var_type, unit_mode)
+            # Append unit to label
+            unit_label = get_unit_label(var_type, unit_mode)
+            label = f"{base_label} [{unit_label}]"
+        else:
+            display_value = str(value) if value is not None else "-"
+            label = base_label
 
         rows.append(
             dmc.Group(
                 [
                     dmc.Text(label, fw=200),
-                    dmc.Text(str(value) if value is not None else "-", c="dimmed"),
+                    dmc.Text(display_value, c="dimmed"),
                 ],
                 justify="space-between",
             )
@@ -59,30 +88,30 @@ def make_metadata_card(metadata: Metadata, fields, title=""):
     )
 
 
-def building_characteristics_card(metadata: Metadata):
+def building_characteristics_card(metadata: Metadata, unit_mode="SI"):
     fields = [
         ("location", "Location"),
         ("building_type", "Building Type"),
         ("vintage", "Vintage"),
         ("climate_zone_output", "Climate Region"),
         ("base_gea_grid_region", "GEA Grid Region"),
-        ("area_sqm", "Building Area (m²)"),
+        ("area_sqm", "Building Area", "area"),
     ]
-    return make_metadata_card(metadata, fields, title="Building Characteristics")
+    return make_metadata_card(metadata, fields, title="Building Characteristics", unit_mode=unit_mode)
 
 
-def load_characteristics_card(metadata: Metadata):
+def load_characteristics_card(metadata: Metadata, unit_mode="SI"):
     load_fields = [
         ("load_data.load_type", "Load Type"),
         ("load_data.annual_heating_cooling_ratio", "Annual H/C Ratio"),
-        ("load_data.hhw_max_load", "Peak Heating Load [W]"),
-        ("load_data.chw_max_load", "Peak Cooling Load [W]"),
-        ("load_data.max_temp", "Max. Outdoor Temp. [°C]"),
-        ("load_data.median_temp", "Median Outdoor Temp. [°C]"),
-        ("load_data.min_temp", "Min. Outdoor Temp. [°C]"),
+        ("load_data.hhw_max_load", "Peak Heating Load", "power"),
+        ("load_data.chw_max_load", "Peak Cooling Load", "power"),
+        ("load_data.max_temp", "Max. Outdoor Temp.", "temperature"),
+        ("load_data.median_temp", "Median Outdoor Temp.", "temperature"),
+        ("load_data.min_temp", "Min. Outdoor Temp.", "temperature"),
     ]
 
-    return make_metadata_card(metadata, load_fields, title="Load Characteristics")
+    return make_metadata_card(metadata, load_fields, title="Load Characteristics", unit_mode=unit_mode)
 
 
 def summary_equipment_selection(equipment_library: EquipmentLibrary, active_tab=None):
@@ -246,16 +275,16 @@ def summary_emissions_selection(metadata: Metadata, active_tab=None):
     )
 
 
-def summary_project_info(metadata: Metadata):
+def summary_project_info(metadata: Metadata, unit_mode="SI"):
 
     overview_fields = [
         ("location", "Location"),
         ("climate_zone_output", "Climate Region"),
         ("building_type", "Building Type"),
-        ("area_sqm", "Building Area (m²)"),
+        ("area_sqm", "Building Area", "area"),
         # Load-side fields (from LoadData)
-        ("load_data.hhw_max_load", "Peak HHW Load [W]"),
-        ("load_data.chw_max_load", "Peak CHW Load [W]"),
+        ("load_data.hhw_max_load", "Peak HHW Load", "power"),
+        ("load_data.chw_max_load", "Peak CHW Load", "power"),
         ("load_data.annual_heating_cooling_ratio", "Annual Heating/Cooling Ratio"),
     ]
 
@@ -263,6 +292,7 @@ def summary_project_info(metadata: Metadata):
         metadata,
         overview_fields,
         title="Project Overview",
+        unit_mode=unit_mode,
     )
 
 

--- a/layout/table_config.py
+++ b/layout/table_config.py
@@ -44,11 +44,12 @@ TABLE_STYLE = ScenarioTableStyle()
 # --- Helpers for table value formatting and styling ---
 
 
-def format_table_value(raw_value):
+def format_table_value(raw_value, field_name: str = None):
     """
     Normalize values for display in tables.
     - None / "None" -> em dash
     - booleans -> Yes / No
+    - Equipment IDs -> model names (when field_name is provided)
     """
     if raw_value is None:
         return "—"
@@ -56,6 +57,14 @@ def format_table_value(raw_value):
         return "-"
     if isinstance(raw_value, bool):
         return "Yes" if raw_value else "No"
+
+    # Map equipment IDs to display names
+    if field_name is not None:
+        from utils.display_registry import EQUIPMENT_ID_FIELDS, get_equipment_display_name
+
+        if field_name in EQUIPMENT_ID_FIELDS:
+            return get_equipment_display_name(raw_value)
+
     return str(raw_value)
 
 

--- a/layout/table_config.py
+++ b/layout/table_config.py
@@ -50,6 +50,7 @@ def format_table_value(raw_value, field_name: str = None):
     - None / "None" -> em dash
     - booleans -> Yes / No
     - Equipment IDs -> model names (when field_name is provided)
+    - Enum values -> user-friendly names (when field_name is provided)
     """
     if raw_value is None:
         return "—"
@@ -58,12 +59,20 @@ def format_table_value(raw_value, field_name: str = None):
     if isinstance(raw_value, bool):
         return "Yes" if raw_value else "No"
 
-    # Map equipment IDs to display names
+    # Map equipment IDs and enum values to display names
     if field_name is not None:
-        from utils.display_registry import EQUIPMENT_ID_FIELDS, get_equipment_display_name
+        from utils.display_registry import (
+            EQUIPMENT_ID_FIELDS,
+            ENUM_VALUE_FIELDS,
+            get_equipment_display_name,
+            format_enum_value,
+        )
 
         if field_name in EQUIPMENT_ID_FIELDS:
             return get_equipment_display_name(raw_value)
+
+        if field_name in ENUM_VALUE_FIELDS:
+            return format_enum_value(raw_value, field_name)
 
     return str(raw_value)
 

--- a/pages/emissions_page.py
+++ b/pages/emissions_page.py
@@ -180,8 +180,9 @@ def layout():
     Input("metadata-store", "data"),
     Input("selected-emissions-store", "data"),
     Input("emissions-view-mode", "value"),
+    Input("unit-toggle", "value"),
 )
-def update_emissions_table(metadata_data, selected_emissions, view_mode):
+def update_emissions_table(metadata_data, selected_emissions, view_mode, unit_mode):
     if not metadata_data:
         return dmc.Text("No emission scenarios defined yet.")
 
@@ -197,6 +198,7 @@ def update_emissions_table(metadata_data, selected_emissions, view_mode):
         scenarios,
         active_ids=active_ids,
         view_mode=view_mode or "simple",
+        unit_mode=unit_mode or "SI",
     )
 
 

--- a/pages/emissions_page.py
+++ b/pages/emissions_page.py
@@ -489,9 +489,10 @@ def remove_emission_scenario(remove_clicks, metadata_data, selected_em_ids):
     Output("edit-em-scenario-error", "children"),
     Input({"type": "emission-edit-btn", "em_scen_id": ALL}, "n_clicks"),
     State("metadata-store", "data"),
+    State("unit-toggle", "value"),
     prevent_initial_call=True,
 )
-def open_edit_emission_modal(edit_clicks, metadata_data):
+def open_edit_emission_modal(edit_clicks, metadata_data, unit_mode):
     if not any(edit_clicks or []):
         return (no_update,) * 11
 
@@ -554,6 +555,15 @@ def open_edit_emission_modal(edit_clicks, metadata_data):
             f"Scenario {em_scen_id!r} not found.",
         )
 
+    # Convert NG leakage for display based on unit mode
+    ng_leakage_base = scen.get("annual_ng_leakage_g_per_kWh")
+    if ng_leakage_base is not None and unit_mode == "IP":
+        from utils.units import get_unit_converter
+        ng_converter = get_unit_converter("ng_leakage_rate", "IP")
+        ng_leakage_display = ng_converter(float(ng_leakage_base))
+    else:
+        ng_leakage_display = ng_leakage_base
+
     return (
         True,
         scen.get("em_scen_id"),
@@ -564,7 +574,7 @@ def open_edit_emission_modal(edit_clicks, metadata_data):
         scen.get("shortrun_weighting"),
         str(scen.get("year")) if scen.get("year") is not None else "",
         scen.get("annual_refrig_leakage_percent"),
-        scen.get("annual_ng_leakage_g_per_kWh"),
+        ng_leakage_display,
         "",
     )
 
@@ -584,6 +594,7 @@ def open_edit_emission_modal(edit_clicks, metadata_data):
     State("edit-em-refrig-leakage", "value"),
     State("edit-em-ng-leakage", "value"),
     State("metadata-store", "data"),
+    State("unit-toggle", "value"),
     prevent_initial_call=True,
 )
 def save_edit_emission(
@@ -598,6 +609,7 @@ def save_edit_emission(
     refrig_leakage,
     ng_leakage,
     metadata_data,
+    unit_mode,
 ):
     if not n_clicks:
         return no_update, no_update, no_update
@@ -630,6 +642,14 @@ def save_edit_emission(
         ng_leakage = float(ng_leakage) if ng_leakage is not None else 0.0
     except (TypeError, ValueError):
         ng_leakage = 0.0
+
+    # Convert NG leakage back to base units (g/kWh) if in IP mode
+    unit_mode = unit_mode or "SI"
+    if unit_mode == "IP" and ng_leakage > 0:
+        from utils.units import g_to_lb, Wh_to_BTU
+        # IP unit is lb/kBTU, convert back to g/kWh
+        # g/kWh = (lb/kBTU) / (g_to_lb / Wh_to_BTU)
+        ng_leakage = ng_leakage / (g_to_lb / Wh_to_BTU)
 
     scenarios = metadata_data.get("emission_settings", [])
     updated = False
@@ -669,6 +689,18 @@ def cancel_edit_emission_modal(n_clicks):
     if not n_clicks:
         return no_update
     return False
+
+
+@callback(
+    Output("edit-em-ng-leakage-label", "children"),
+    Input("unit-toggle", "value"),
+)
+def update_ng_leakage_label(unit_mode):
+    """Update NG leakage label based on unit mode."""
+    from utils.units import get_unit_label
+    unit_mode = unit_mode or "SI"
+    ng_unit = get_unit_label("ng_leakage_rate", unit_mode)
+    return f"Annual NG leakage ({ng_unit})"
 
 
 @callback(

--- a/pages/emissions_page.py
+++ b/pages/emissions_page.py
@@ -564,6 +564,15 @@ def open_edit_emission_modal(edit_clicks, metadata_data, unit_mode):
     else:
         ng_leakage_display = ng_leakage_base
 
+    # Round refrigerant leakage to 2 decimal places for display
+    refrig_leakage = scen.get("annual_refrig_leakage_percent")
+    if refrig_leakage is not None:
+        refrig_leakage = round(float(refrig_leakage), 2)
+
+    # Round NG leakage display to 2 decimal places
+    if ng_leakage_display is not None:
+        ng_leakage_display = round(float(ng_leakage_display), 2)
+
     return (
         True,
         scen.get("em_scen_id"),
@@ -573,7 +582,7 @@ def open_edit_emission_modal(edit_clicks, metadata_data, unit_mode):
         scen.get("emission_type", ""),
         scen.get("shortrun_weighting"),
         str(scen.get("year")) if scen.get("year") is not None else "",
-        scen.get("annual_refrig_leakage_percent"),
+        refrig_leakage,
         ng_leakage_display,
         "",
     )

--- a/pages/loads_page.py
+++ b/pages/loads_page.py
@@ -22,6 +22,7 @@ from layout.input import (
     select_load_type,
     modal_load_data_selection,
     build_building_table,
+    LOAD_INDEX,  # slider min/max values in base SI units
 )
 
 from layout.output import (
@@ -327,7 +328,7 @@ def confirm_selection(n_clicks, current_choice, metadata_data, session_data):
         if not isinstance(df.index, pd.DatetimeIndex):
             raise ValueError("Expected DatetimeIndex in StandardLoad.df")
 
-        # Monthly peaks (HHW & CHW, W → kW)
+        # Monthly peaks (HHW & CHW) - keep in base units (W)
         monthly = df.copy()
         monthly["month"] = monthly.index.month
         peaks = (
@@ -339,8 +340,8 @@ def confirm_selection(n_clicks, current_choice, metadata_data, session_data):
         monthly_summary = [
             {
                 "month": int(row["month"]),
-                "HHW_kW": float(row["heating_W"] / 1000.0),
-                "CHW_kW": float(row["cooling_W"] / 1000.0),
+                "HHW_W": float(row["heating_W"]),
+                "CHW_W": float(row["cooling_W"]),
             }
             for _, row in peaks.iterrows()
         ]
@@ -376,8 +377,8 @@ def confirm_selection(n_clicks, current_choice, metadata_data, session_data):
         temp_summary = [
             {
                 "center": float(row["t_bin"]) if row["t_bin"] is not None else None,
-                "HHW_kW": float(row["heating_W"] / 1000.0),
-                "CHW_kW": float(row["cooling_W"] / 1000.0),
+                "HHW_W": float(row["heating_W"]),
+                "CHW_W": float(row["cooling_W"]),
             }
             for _, row in bin_stats.iterrows()
         ]
@@ -521,6 +522,7 @@ def process_upload(contents, filename, metadata_data):
         Input("chw-range-slider", "value"),
         # Input("temp-range-slider", "value"),
         Input("metadata-store", "data"),  # re-sort when metadata changes
+        Input("unit-toggle", "value"),  # unit mode for table display
     ],
     State("building-radio-group", "value"),
 )
@@ -533,8 +535,42 @@ def update_table(
     chw_range,
     # temp_range,
     metadata_data,
+    unit_mode,
     current_choice,
 ):
+    from utils.units import sqm_to_sqft, W_to_BTUh
+
+    unit_mode = unit_mode or "SI"
+
+    # -----------------------------
+    # Convert slider values back to base SI units for filtering
+    # Sliders show: SI mode = kW, IP mode = BTU/h (for power)
+    # Data is stored in: W (for power), m² (for area)
+    # -----------------------------
+    if area_range and len(area_range) == 2:
+        if unit_mode == "IP":
+            # ft² → m²
+            area_range = [a / 10.7639 for a in area_range]
+        else:
+            # Already in m² (slider shows m² in SI mode)
+            pass
+
+    if hhw_range and len(hhw_range) == 2:
+        if unit_mode == "IP":
+            # BTU/h → W
+            hhw_range = [h / W_to_BTUh for h in hhw_range]
+        else:
+            # kW → W
+            hhw_range = [h * 1000 for h in hhw_range]
+
+    if chw_range and len(chw_range) == 2:
+        if unit_mode == "IP":
+            # BTU/h → W
+            chw_range = [c / W_to_BTUh for c in chw_range]
+        else:
+            # kW → W
+            chw_range = [c * 1000 for c in chw_range]
+
     # -----------------------------
     # 0) Base filter: load_type
     # -----------------------------
@@ -547,7 +583,7 @@ def update_table(
             df = buildings_df.copy()
 
     if df.empty:
-        return build_building_table(df, selected_id=None)
+        return build_building_table(df, selected_id=None, unit_mode=unit_mode)
 
     # -----------------------------
     # 1) Additional filters
@@ -567,7 +603,7 @@ def update_table(
     if building_type_filter and "building_type" in df.columns:
         df = df[df["building_type"] == building_type_filter]
 
-    # Area range filter (try area_sqm or area_m2)
+    # Area range filter (try area_sqm or area_m2) - values now in m²
     if area_range and len(area_range) == 2:
         amin, amax = area_range
         area_col = None
@@ -578,18 +614,18 @@ def update_table(
         if area_col:
             df = df[df[area_col].between(amin, amax)]
 
-    # HHW peak range filter
+    # HHW peak range filter - values now in W
     if hhw_range and len(hhw_range) == 2 and "hhw_max_load" in df.columns:
         hmin, hmax = hhw_range
         df = df[df["hhw_max_load"].between(hmin, hmax)]
 
-    # CHW peak range filter
+    # CHW peak range filter - values now in W
     if chw_range and len(chw_range) == 2 and "chw_max_load" in df.columns:
         cmin, cmax = chw_range
         df = df[df["chw_max_load"].between(cmin, cmax)]
 
     if df.empty:
-        return build_building_table(df, selected_id=None)
+        return build_building_table(df, selected_id=None, unit_mode=unit_mode)
 
     # -----------------------------
     # 2) Metadata-based priority sort (unchanged)
@@ -657,7 +693,135 @@ def update_table(
         if current_choice is not None and str(current_choice) in visible_ids:
             selected_id = current_choice
 
-    return build_building_table(df, selected_id)
+    return build_building_table(df, selected_id, unit_mode=unit_mode)
+
+
+# -------------------------------------------------------------------
+# Callback: update slider labels and properties based on unit_mode
+# -------------------------------------------------------------------
+@callback(
+    # Slider labels
+    Output("area-slider-label", "children"),
+    Output("hhw-slider-label", "children"),
+    Output("chw-slider-label", "children"),
+    # Slider properties (min, max, step, marks, value)
+    Output("area-range-slider", "min"),
+    Output("area-range-slider", "max"),
+    Output("area-range-slider", "step"),
+    Output("area-range-slider", "marks"),
+    Output("area-range-slider", "value"),
+    Output("hhw-range-slider", "min"),
+    Output("hhw-range-slider", "max"),
+    Output("hhw-range-slider", "step"),
+    Output("hhw-range-slider", "marks"),
+    Output("hhw-range-slider", "value"),
+    Output("chw-range-slider", "min"),
+    Output("chw-range-slider", "max"),
+    Output("chw-range-slider", "step"),
+    Output("chw-range-slider", "marks"),
+    Output("chw-range-slider", "value"),
+    Input("unit-toggle", "value"),
+    prevent_initial_call=False,
+)
+def update_slider_units(unit_mode):
+    """Update slider labels and ranges based on unit mode (SI/IP)."""
+    from utils.units import get_display_unit, sqm_to_sqft, W_to_BTUh
+
+    unit_mode = unit_mode or "SI"
+
+    # Get base values from LOAD_INDEX (in SI units)
+    area_min_si, area_max_si = LOAD_INDEX["area_sqm"]
+    hhw_min_si, hhw_max_si = LOAD_INDEX["hhw_max_load"]
+    chw_min_si, chw_max_si = LOAD_INDEX["chw_max_load"]
+
+    # Get display units
+    area_unit = get_display_unit("area", unit_mode)
+    power_unit = get_display_unit("power", unit_mode)  # BTU/h for heating
+    power_cooling_unit = get_display_unit("power_cooling", unit_mode)  # TR for cooling
+
+    if unit_mode == "IP":
+        # Convert area: m² → ft²
+        area_min = int(sqm_to_sqft(area_min_si))
+        area_max = int(sqm_to_sqft(area_max_si))
+        area_step = 5000
+
+        # Convert power: W → BTU/h (for both HHW and CHW display)
+        # Using heating units for both sliders for consistency
+        hhw_min = int(hhw_min_si * W_to_BTUh)
+        hhw_max = int(hhw_max_si * W_to_BTUh)
+        hhw_step = 50000
+
+        chw_min = int(chw_min_si * W_to_BTUh)
+        chw_max = int(chw_max_si * W_to_BTUh)
+        chw_step = 50000
+    else:
+        # SI mode - use kW for power
+        area_min = area_min_si
+        area_max = area_max_si
+        area_step = 500
+
+        # Convert W to kW for display
+        hhw_min = int(hhw_min_si / 1000)
+        hhw_max = int(hhw_max_si / 1000)
+        hhw_step = 50
+
+        chw_min = int(chw_min_si / 1000)
+        chw_max = int(chw_max_si / 1000)
+        chw_step = 50
+
+    # Format mark labels
+    def format_large_number(n):
+        if abs(n) >= 1_000_000:
+            return f"{n / 1_000_000:.1f}M"
+        elif abs(n) >= 1_000:
+            return f"{n / 1_000:.0f}k"
+        return str(int(n))
+
+    # Build labels (use kW for SI power, BTU/h for IP power)
+    power_label_unit = "kW" if unit_mode == "SI" else "BTU/h"
+
+    area_label = f"Area ({area_unit})"
+    hhw_label = f"HHW Peak Load [{power_label_unit}]"
+    chw_label = f"CHW Peak Load [{power_label_unit}]"
+
+    # Build marks
+    area_marks = [
+        {"value": area_min, "label": format_large_number(area_min)},
+        {"value": area_max, "label": format_large_number(area_max)},
+    ]
+    hhw_marks = [
+        {"value": hhw_min, "label": format_large_number(hhw_min)},
+        {"value": hhw_max, "label": format_large_number(hhw_max)},
+    ]
+    chw_marks = [
+        {"value": chw_min, "label": format_large_number(chw_min)},
+        {"value": chw_max, "label": format_large_number(chw_max)},
+    ]
+
+    return (
+        # Labels
+        area_label,
+        hhw_label,
+        chw_label,
+        # Area slider
+        area_min,
+        area_max,
+        area_step,
+        area_marks,
+        [area_min, area_max],
+        # HHW slider
+        hhw_min,
+        hhw_max,
+        hhw_step,
+        hhw_marks,
+        [hhw_min, hhw_max],
+        # CHW slider
+        chw_min,
+        chw_max,
+        chw_step,
+        chw_marks,
+        [chw_min, chw_max],
+    )
 
 
 # -------------------------------------------------------------------
@@ -755,10 +919,8 @@ def update_load_visualization(summary_data, pathname, unit_mode):
     unit_mode = unit_mode or "SI"
 
     # Import unit conversion helpers
-    from utils.units import get_unit_converter, get_unit_label, C_to_F
+    from utils.units import get_unit_label, C_to_F, get_auto_scale_for_values
 
-    power_converter = get_unit_converter("power_kw", unit_mode)
-    power_unit = get_unit_label("power_kw", unit_mode)
     temp_unit = get_unit_label("temperature", unit_mode)
 
     try:
@@ -766,13 +928,36 @@ def update_load_visualization(summary_data, pathname, unit_mode):
         temp_summary = summary_data.get("temp_bins", []) or []
 
         # ------------------------------------------------------------------
+        # Determine auto-scaling for power values (already in base units W)
+        # ------------------------------------------------------------------
+        all_power_w = []
+        for item in monthly_summary:
+            all_power_w.extend([item["HHW_W"], item["CHW_W"]])
+        for item in temp_summary:
+            all_power_w.extend([item["HHW_W"], item["CHW_W"]])
+
+        # Filter out None values
+        all_power_w = [w for w in all_power_w if w is not None]
+
+        # Get auto-scale (scale_factor, unit_label) - works directly with base units
+        power_scale, power_unit = get_auto_scale_for_values(
+            all_power_w, "power", unit_mode
+        )
+
+        # Helper to scale W values to display values
+        def scale_power(w):
+            if w is None:
+                return 0
+            return w / power_scale
+
+        # ------------------------------------------------------------------
         # Chart 1: Monthly peak HHW & CHW from summary
         # ------------------------------------------------------------------
         monthly_data = [
             {
                 "month": calendar.month_abbr[item["month"]],
-                "HHW": round(power_converter(item["HHW_kW"]), 0),
-                "CHW": round(power_converter(item["CHW_kW"]), 0),
+                "HHW": round(scale_power(item["HHW_W"]), 1),
+                "CHW": round(scale_power(item["CHW_W"]), 1),
             }
             for item in monthly_summary
         ]
@@ -806,11 +991,13 @@ def update_load_visualization(summary_data, pathname, unit_mode):
                 bin_label = f"{int(temp_val)} {temp_unit}"
             else:
                 bin_label = "N/A"
-            bin_data.append({
-                "bin": bin_label,
-                "HHW": round(power_converter(item["HHW_kW"]), 0),
-                "CHW": round(power_converter(item["CHW_kW"]), 0),
-            })
+            bin_data.append(
+                {
+                    "bin": bin_label,
+                    "HHW": round(scale_power(item["HHW_W"]), 1),
+                    "CHW": round(scale_power(item["CHW_W"]), 1),
+                }
+            )
 
         temp_chart = dmc.CompositeChart(
             h=260,

--- a/pages/loads_page.py
+++ b/pages/loads_page.py
@@ -408,17 +408,22 @@ def confirm_selection(n_clicks, current_choice, metadata_data, session_data):
     )
 
 
-@callback(Output("summary-selection-info", "children"), Input("metadata-store", "data"))
-def show_metadata(data):
+@callback(
+    Output("summary-selection-info", "children"),
+    Input("metadata-store", "data"),
+    Input("unit-toggle", "value"),
+)
+def show_metadata(data, unit_mode):
     if not data:
         return "No metadata yet"
 
+    unit_mode = unit_mode or "SI"
     metadata = Metadata(**data)
 
     return (
-        building_characteristics_card(metadata),
+        building_characteristics_card(metadata, unit_mode=unit_mode),
         dmc.Space(h=10),
-        load_characteristics_card(metadata),
+        load_characteristics_card(metadata, unit_mode=unit_mode),
     )
 
 
@@ -733,10 +738,11 @@ def update_selected_text(current_choice):
     [
         Input("load-summary-store", "data"),
         Input("url", "pathname"),
+        Input("unit-toggle", "value"),
     ],
     prevent_initial_call=False,
 )
-def update_load_visualization(summary_data, pathname):
+def update_load_visualization(summary_data, pathname, unit_mode):
 
     # Only draw when we are on the Loads page
     if pathname != URLS.HOME.value:
@@ -746,18 +752,27 @@ def update_load_visualization(summary_data, pathname):
     if not summary_data:
         raise dash.exceptions.PreventUpdate
 
+    unit_mode = unit_mode or "SI"
+
+    # Import unit conversion helpers
+    from utils.units import get_unit_converter, get_unit_label, C_to_F
+
+    power_converter = get_unit_converter("power_kw", unit_mode)
+    power_unit = get_unit_label("power_kw", unit_mode)
+    temp_unit = get_unit_label("temperature", unit_mode)
+
     try:
         monthly_summary = summary_data.get("monthly_peaks", []) or []
         temp_summary = summary_data.get("temp_bins", []) or []
 
         # ------------------------------------------------------------------
-        # Chart 1: Monthly peak HHW & CHW (kW) from summary
+        # Chart 1: Monthly peak HHW & CHW from summary
         # ------------------------------------------------------------------
         monthly_data = [
             {
                 "month": calendar.month_abbr[item["month"]],
-                "HHW": round(item["HHW_kW"], 0),
-                "CHW": round(item["CHW_kW"], 0),
+                "HHW": round(power_converter(item["HHW_kW"]), 0),
+                "CHW": round(power_converter(item["CHW_kW"]), 0),
             }
             for item in monthly_summary
         ]
@@ -768,7 +783,7 @@ def update_load_visualization(summary_data, pathname):
             dataKey="month",
             withLegend=True,
             xAxisLabel="Month",
-            yAxisLabel="Peak load (kW)",
+            yAxisLabel=f"Peak load ({power_unit})",
             curveType="linear",
             tooltipAnimationDuration=200,
             series=[
@@ -778,32 +793,41 @@ def update_load_visualization(summary_data, pathname):
         )
 
         # ------------------------------------------------------------------
-        # Chart 2: HHW & CHW vs 5°C T_out bins from summary
+        # Chart 2: HHW & CHW vs temperature bins from summary
         # ------------------------------------------------------------------
-        bin_data = [
-            {
-                "bin": (
-                    f"{int(item['center'])} °C" if item["center"] is not None else "N/A"
-                ),
-                "HHW": round(item["HHW_kW"], 0),
-                "CHW": round(item["CHW_kW"], 0),
-            }
-            for item in temp_summary
-        ]
+        bin_data = []
+        for item in temp_summary:
+            if item["center"] is not None:
+                if unit_mode == "IP":
+                    # Convert to °F and round to nearest 10 for cleaner labels
+                    temp_val = round(C_to_F(item["center"]) / 10) * 10
+                else:
+                    temp_val = item["center"]
+                bin_label = f"{int(temp_val)} {temp_unit}"
+            else:
+                bin_label = "N/A"
+            bin_data.append({
+                "bin": bin_label,
+                "HHW": round(power_converter(item["HHW_kW"]), 0),
+                "CHW": round(power_converter(item["CHW_kW"]), 0),
+            })
 
         temp_chart = dmc.CompositeChart(
             h=260,
             data=bin_data,
             dataKey="bin",
             withLegend=True,
-            xAxisLabel="Outdoor temperature (°C)",
-            yAxisLabel="Avg load (kW)",
+            xAxisLabel=f"Outdoor temperature ({temp_unit})",
+            yAxisLabel=f"Avg load ({power_unit})",
             tooltipAnimationDuration=200,
             series=[
                 {"name": "HHW", "type": "bar", "color": "red.6", "yAxisId": "left"},
                 {"name": "CHW", "type": "bar", "color": "blue.6", "yAxisId": "left"},
             ],
         )
+
+        # Dynamic bin size description
+        bin_size_desc = "~10°F" if unit_mode == "IP" else "5°C"
 
         return dmc.Stack(
             [
@@ -815,7 +839,7 @@ def update_load_visualization(summary_data, pathname):
                 monthly_chart,
                 dmc.Divider(my="sm"),
                 dmc.Text(
-                    "Average heating and cooling vs outdoor temperature bins (5°C)",
+                    f"Average heating and cooling vs outdoor temperature bins ({bin_size_desc})",
                     size="sm",
                     c="dimmed",
                 ),

--- a/pages/loads_page.py
+++ b/pages/loads_page.py
@@ -538,13 +538,13 @@ def update_table(
     unit_mode,
     current_choice,
 ):
-    from utils.units import sqm_to_sqft, W_to_BTUh
+    from utils.units import sqm_to_sqft, W_to_BTUh, ton_to_W
 
     unit_mode = unit_mode or "SI"
 
     # -----------------------------
     # Convert slider values back to base SI units for filtering
-    # Sliders show: SI mode = kW, IP mode = BTU/h (for power)
+    # Sliders show: SI mode = kW, IP mode = MMBTU/h (heating) / TR (cooling)
     # Data is stored in: W (for power), m² (for area)
     # -----------------------------
     if area_range and len(area_range) == 2:
@@ -557,16 +557,17 @@ def update_table(
 
     if hhw_range and len(hhw_range) == 2:
         if unit_mode == "IP":
-            # BTU/h → W
-            hhw_range = [h / W_to_BTUh for h in hhw_range]
+            # MMBTU/h → W (1 MMBTU/h = 1e6 BTU/h = 1e6/3.412 W)
+            w_per_mmbtu = 1e6 / W_to_BTUh
+            hhw_range = [h * w_per_mmbtu for h in hhw_range]
         else:
             # kW → W
             hhw_range = [h * 1000 for h in hhw_range]
 
     if chw_range and len(chw_range) == 2:
         if unit_mode == "IP":
-            # BTU/h → W
-            chw_range = [c / W_to_BTUh for c in chw_range]
+            # TR → W (1 TR = 3517 W)
+            chw_range = [c * ton_to_W for c in chw_range]
         else:
             # kW → W
             chw_range = [c * 1000 for c in chw_range]
@@ -725,19 +726,17 @@ def update_table(
 )
 def update_slider_units(unit_mode):
     """Update slider labels and ranges based on unit mode (SI/IP)."""
-    from utils.units import get_display_unit, sqm_to_sqft, W_to_BTUh
+    from utils.units import get_display_unit, sqm_to_sqft, W_to_BTUh, W_to_tons
 
     unit_mode = unit_mode or "SI"
 
-    # Get base values from LOAD_INDEX (in SI units)
+    # Get base values from LOAD_INDEX (in SI units, stored as W)
     area_min_si, area_max_si = LOAD_INDEX["area_sqm"]
     hhw_min_si, hhw_max_si = LOAD_INDEX["hhw_max_load"]
     chw_min_si, chw_max_si = LOAD_INDEX["chw_max_load"]
 
     # Get display units
     area_unit = get_display_unit("area", unit_mode)
-    power_unit = get_display_unit("power", unit_mode)  # BTU/h for heating
-    power_cooling_unit = get_display_unit("power_cooling", unit_mode)  # TR for cooling
 
     if unit_mode == "IP":
         # Convert area: m² → ft²
@@ -745,15 +744,19 @@ def update_slider_units(unit_mode):
         area_max = int(sqm_to_sqft(area_max_si))
         area_step = 5000
 
-        # Convert power: W → BTU/h (for both HHW and CHW display)
-        # Using heating units for both sliders for consistency
-        hhw_min = int(hhw_min_si * W_to_BTUh)
-        hhw_max = int(hhw_max_si * W_to_BTUh)
-        hhw_step = 50000
+        # Convert HHW: W → MMBTU/h (1 MMBTU/h = 1e6 BTU/h = 1e6/3.412 W)
+        # Using MMBTU/h to avoid excessively large numbers
+        mmbtu_per_w = W_to_BTUh / 1e6  # W to MMBTU/h
+        hhw_min = round(hhw_min_si * mmbtu_per_w, 1)
+        hhw_max = round(hhw_max_si * mmbtu_per_w, 1)
+        hhw_step = 0.5
+        hhw_label_unit = "MMBTU/h"
 
-        chw_min = int(chw_min_si * W_to_BTUh)
-        chw_max = int(chw_max_si * W_to_BTUh)
-        chw_step = 50000
+        # Convert CHW: W → TR (tons of refrigeration)
+        chw_min = round(W_to_tons(chw_min_si), 0)
+        chw_max = round(W_to_tons(chw_max_si), 0)
+        chw_step = 50
+        chw_label_unit = "TR"
     else:
         # SI mode - use kW for power
         area_min = area_min_si
@@ -764,10 +767,12 @@ def update_slider_units(unit_mode):
         hhw_min = int(hhw_min_si / 1000)
         hhw_max = int(hhw_max_si / 1000)
         hhw_step = 50
+        hhw_label_unit = "kW"
 
         chw_min = int(chw_min_si / 1000)
         chw_max = int(chw_max_si / 1000)
         chw_step = 50
+        chw_label_unit = "kW"
 
     # Format mark labels
     def format_large_number(n):
@@ -775,14 +780,11 @@ def update_slider_units(unit_mode):
             return f"{n / 1_000_000:.1f}M"
         elif abs(n) >= 1_000:
             return f"{n / 1_000:.0f}k"
-        return str(int(n))
-
-    # Build labels (use kW for SI power, BTU/h for IP power)
-    power_label_unit = "kW" if unit_mode == "SI" else "BTU/h"
+        return f"{n:.1f}" if isinstance(n, float) else str(int(n))
 
     area_label = f"Area ({area_unit})"
-    hhw_label = f"HHW Peak Load [{power_label_unit}]"
-    chw_label = f"CHW Peak Load [{power_label_unit}]"
+    hhw_label = f"HHW Peak Load [{hhw_label_unit}]"
+    chw_label = f"CHW Peak Load [{chw_label_unit}]"
 
     # Build marks
     area_marks = [

--- a/pages/results_page.py
+++ b/pages/results_page.py
@@ -258,6 +258,35 @@ def update_scatter_plot(
     return fig
 
 
+# Immediate notification when download button is clicked
+@callback(
+    Output("notification-container", "sendNotifications", allow_duplicate=True),
+    Input("download-button", "n_clicks"),
+    State("unit-toggle", "value"),
+    prevent_initial_call=True,
+)
+def show_download_notification(n_clicks, unit_mode):
+    """Show immediate feedback when download button is clicked."""
+    if not n_clicks:
+        raise dash.exceptions.PreventUpdate
+
+    unit_mode = unit_mode or "SI"
+    unit_label = "SI (metric)" if unit_mode == "SI" else "IP (imperial)"
+
+    # Notification with loading spinner
+    notification = {
+        "id": "download-notification",
+        "title": "Preparing Download",
+        "message": f"Exporting results in {unit_label} units...",
+        "color": "blue",
+        "loading": True,  # Shows spinning wheel
+        "autoClose": 6000,  # Keep visible longer (6 seconds)
+        "action": "show",
+    }
+
+    return [notification]
+
+
 # Download the full results/source energy dataframe as CSV
 @callback(
     Output("download-data", "data"),
@@ -268,6 +297,7 @@ def update_scatter_plot(
 )
 def download_results(n_clicks, session_data, unit_mode):
     """Download the entire results dataframe as a .csv file with unit conversion."""
+    import numpy as np
     from utils.units import (
         convert_dataframe,
         get_category,
@@ -275,13 +305,33 @@ def download_results(n_clicks, session_data, unit_mode):
         COLUMN_DISPLAY_NAMES,
     )
 
+    # Only trigger on actual button click
+    if not n_clicks:
+        raise dash.exceptions.PreventUpdate
+
     if not session_data or "session_id" not in session_data:
         raise dash.exceptions.PreventUpdate
 
     df = load_source_energy(session_data)
+    if df is None:
+        raise dash.exceptions.PreventUpdate
+
+    unit_mode = unit_mode or "SI"
 
     # Convert values based on unit mode
     df = convert_dataframe(df, unit_mode)
+
+    # Round numeric values: 2 decimals normally, 3 for values < 1
+    def smart_round(val):
+        if pd.isna(val) or not isinstance(val, (int, float, np.number)):
+            return val
+        if abs(val) < 1 and val != 0:
+            return round(val, 3)
+        return round(val, 2)
+
+    for col in df.columns:
+        if df[col].dtype in [np.float64, np.float32, float]:
+            df[col] = df[col].apply(smart_round)
 
     # Rename columns:
     # - Columns with a category: use get_column_label (includes unit)

--- a/pages/results_page.py
+++ b/pages/results_page.py
@@ -263,14 +263,39 @@ def update_scatter_plot(
     Output("download-data", "data"),
     Input("download-button", "n_clicks"),
     State("session-store", "data"),
+    State("unit-toggle", "value"),
     prevent_initial_call=True,
 )
-def download_results(n_clicks, session_data):
-    """Download the entire results dataframe as a .csv file"""
+def download_results(n_clicks, session_data, unit_mode):
+    """Download the entire results dataframe as a .csv file with unit conversion."""
+    from utils.units import (
+        convert_dataframe,
+        get_category,
+        get_column_label,
+        COLUMN_DISPLAY_NAMES,
+    )
+
     if not session_data or "session_id" not in session_data:
         raise dash.exceptions.PreventUpdate
 
     df = load_source_energy(session_data)
+
+    # Convert values based on unit mode
+    df = convert_dataframe(df, unit_mode)
+
+    # Rename columns:
+    # - Columns with a category: use get_column_label (includes unit)
+    # - Columns without a category but with display name: use display name only
+    column_renames = {}
+    for col in df.columns:
+        if get_category(col) is not None:
+            # Has unit conversion - include unit in label
+            column_renames[col] = get_column_label(col, unit_mode)
+        elif col in COLUMN_DISPLAY_NAMES:
+            # No unit conversion but has display name
+            column_renames[col] = COLUMN_DISPLAY_NAMES[col]
+        # else: keep original column name
+    df = df.rename(columns=column_renames)
 
     filename = f"results_{datetime.datetime.now()}.csv"
 

--- a/pages/results_page.py
+++ b/pages/results_page.py
@@ -96,13 +96,15 @@ def load_source_energy(session_data):
 @callback(
     Output("summary-project-info", "children"),
     Input("metadata-store", "data"),
+    Input("unit-toggle", "value"),
 )
-def show_project_summary(metadata_json):
+def show_project_summary(metadata_json, unit_mode):
     if not metadata_json:
         return "No project metadata available."
 
+    unit_mode = unit_mode or "SI"
     metadata = Metadata(**metadata_json)
-    return summary_project_info(metadata)
+    return summary_project_info(metadata, unit_mode=unit_mode)
 
 
 @callback(

--- a/pages/results_page.py
+++ b/pages/results_page.py
@@ -24,6 +24,10 @@ from src.visuals import (
 )
 
 from utils.logging_config import get_logger
+from utils.display_registry import (
+    format_equipment_scenario_id,
+    format_emission_scenario_id,
+)
 
 logger = get_logger(__name__)
 
@@ -308,12 +312,26 @@ def populate_equipment_dropdowns(session_data, selected_equipment_ids):
     else:
         eq_ids = df_ids
 
+    # Sort equipment scenarios by their numeric suffix (eq_scenario_1 < eq_scenario_2 < ...)
+    def eq_sort_key(scen_id):
+        if scen_id.startswith("eq_scenario_"):
+            try:
+                return int(scen_id[len("eq_scenario_") :])
+            except ValueError:
+                pass
+        return scen_id
+
+    eq_ids = sorted(eq_ids, key=eq_sort_key)
+
     if not eq_ids:
         # Fallback: nothing computed
         return [], [], [], None, [], None, [], []
 
-    # Build options list
-    options = [{"label": scen_id, "value": scen_id} for scen_id in eq_ids]
+    # Build options list with user-friendly labels
+    options = [
+        {"label": format_equipment_scenario_id(scen_id), "value": scen_id}
+        for scen_id in eq_ids
+    ]
 
     # Defaults:
     # - For multi-select dropdowns: select all by default
@@ -410,6 +428,14 @@ def populate_emission_dropdowns(
     else:
         em_ids = df_ids
 
+    # Sort emission scenarios by their letter suffix (em_scenario_a < em_scenario_b < ...)
+    def em_sort_key(scen_id):
+        if scen_id.startswith("em_scenario_"):
+            return scen_id[len("em_scenario_") :]
+        return scen_id
+
+    em_ids = sorted(em_ids, key=em_sort_key)
+
     if not em_ids:
         empty_opts, none_val = [], None
         return (
@@ -425,8 +451,11 @@ def populate_emission_dropdowns(
             none_val,
         )
 
-    # Build options
-    options = [{"label": scen_id, "value": scen_id} for scen_id in em_ids]
+    # Build options with user-friendly labels
+    options = [
+        {"label": format_emission_scenario_id(scen_id), "value": scen_id}
+        for scen_id in em_ids
+    ]
 
     # Helper: choose new value based on previous value type (single vs multi)
     def pick_value(prev_val):

--- a/src/visuals.py
+++ b/src/visuals.py
@@ -4,7 +4,15 @@ import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
-from utils.units import unit_map, get_unit_converter, get_hover_unit
+from utils.units import (
+    convert_dataframe,
+    get_display_unit,
+    get_auto_scale,
+    get_converter,
+    format_large_number,
+    # Legacy import for backward compatibility (axis labels with HTML)
+    unit_map,
+)
 from utils.display_registry import format_emission_scenario_id, format_meter_name
 
 
@@ -54,21 +62,6 @@ def shorten_scenario_name(scen_name, max_length=15):
 def plot_energy_and_emissions(
     df, equipment_scenarios, emission_scenarios, unit_mode="SI"
 ):
-
-    col_to_type = {
-        # Energy
-        "elec_hr_Wh": "energy",
-        "elec_awhp_h_Wh": "energy",
-        "elec_awhp_c_Wh": "energy",
-        "elec_res_Wh": "energy",
-        "elec_chiller_Wh": "energy",
-        "gas_boiler_Wh": "energy",
-        # Emissions
-        "elec_emissions": "emissions",
-        "gas_emissions": "emissions",
-        "total_refrig_emissions": "emissions",
-    }
-
     # --- Filter scenarios ---
     df = df[
         (df["eq_scen_id"].isin(equipment_scenarios))
@@ -81,20 +74,35 @@ def plot_energy_and_emissions(
     n_scen = len(scenarios)
     opacities = np.linspace(1, 1, n_scen)  # fade scenarios slightly, ignore for now
 
-    # --- Convert all columns according to unit mode ---
-    for col in df.columns:
-        if col in col_to_type:
-            var_type = col_to_type[col]
-            conv = get_unit_converter(var_type, unit_mode)
-            df.loc[:, col] = df[col].apply(conv)
+    # NOTE: Don't use convert_dataframe - we use auto-scaling directly from base units
 
-    # --- Axis labels ---
-    yaxis_title_energy = unit_map["energy"][unit_mode]["label"]
-    yaxis_title_emissions = unit_map["emissions"][unit_mode]["label"]
+    # --- Pre-calculate totals in BASE units to determine auto-scaling ---
+    energy_totals = []
+    emissions_totals = []
+    for scen in scenarios:
+        df_s = df[df["eq_scen_id"] == scen]
+        # Energy columns are in Wh (base unit)
+        elec = df_s[["elec_hr_Wh", "elec_awhp_h_Wh", "elec_awhp_c_Wh", "elec_res_Wh", "elec_chiller_Wh"]].sum().sum()
+        gas = df_s["gas_boiler_Wh"].sum()
+        energy_totals.extend([elec, gas])
 
-    # --- Hover units ---
-    energy_hover_unit = get_hover_unit("energy", unit_mode)
-    emissions_hover_unit = get_hover_unit("emissions", unit_mode)
+        # Emissions columns are in kg CO₂e (base unit)
+        elec_em = df_s["elec_emissions"].sum()
+        gas_em = df_s["gas_emissions"].sum()
+        refrig_em = df_s["total_refrig_emissions"].sum()
+        emissions_totals.extend([elec_em, gas_em, refrig_em])
+
+    # --- Determine auto-scaling (from base units directly) ---
+    energy_scale, energy_unit = get_auto_scale(energy_totals, "energy", unit_mode)
+    emissions_scale, emissions_unit = get_auto_scale(emissions_totals, "emissions", unit_mode)
+
+    # --- Axis labels with auto-scaled units ---
+    yaxis_title_energy = f'Energy <span style="font-weight:200">| {energy_unit}</span>'
+    yaxis_title_emissions = f'Emissions <span style="font-weight:200">| {emissions_unit}</span>'
+
+    # --- Hover units (use scaled units) ---
+    energy_hover_unit = energy_unit
+    emissions_hover_unit = emissions_unit
 
     # --- Colors ---
     color_map_energy = {"Electricity": berkeley_blue, "Gas": berkeley_gold}
@@ -134,18 +142,22 @@ def plot_energy_and_emissions(
         )
         gas_total = df_s["gas_boiler_Wh"].sum()
 
+        # Apply auto-scaling
+        elec_scaled = elec_total / energy_scale
+        gas_scaled = gas_total / energy_scale
+
         # Electricity
         fig.add_trace(
             go.Bar(
                 x=[scen_name_short],
-                y=[elec_total],
+                y=[elec_scaled],
                 name="Electricity",
                 marker=dict(
                     color=color_map_energy["Electricity"], opacity=opacities[i]
                 ),
                 hovertemplate=(
                     f"Scenario: {scen_name}<br>"
-                    f"Electricity: {elec_total:.0f} {energy_hover_unit}"
+                    f"Electricity: {elec_scaled:,.1f} {energy_hover_unit}"
                     "<extra></extra>"
                 ),
                 showlegend=False,
@@ -158,12 +170,12 @@ def plot_energy_and_emissions(
         fig.add_trace(
             go.Bar(
                 x=[scen_name_short],
-                y=[gas_total],
+                y=[gas_scaled],
                 name="Gas",
                 marker=dict(color=color_map_energy["Gas"], opacity=opacities[i]),
                 hovertemplate=(
                     f"Scenario: {scen_name}<br>"
-                    f"Gas: {gas_total:.0f} {energy_hover_unit}"
+                    f"Gas: {gas_scaled:,.1f} {energy_hover_unit}"
                     "<extra></extra>"
                 ),
                 showlegend=False,
@@ -184,18 +196,23 @@ def plot_energy_and_emissions(
         gas_em = df_s["gas_emissions"].sum().sum()
         refrig_em = df_s["total_refrig_emissions"].sum().sum()
 
+        # Apply auto-scaling
+        elec_em_scaled = elec_em / emissions_scale
+        gas_em_scaled = gas_em / emissions_scale
+        refrig_em_scaled = refrig_em / emissions_scale
+
         show_legend = "Electricity" not in added_legends
         fig.add_trace(
             go.Bar(
                 x=[scen_name_short],
-                y=[elec_em],
+                y=[elec_em_scaled],
                 name="Electricity",
                 marker=dict(
                     color=color_map_emissions["Electricity"], opacity=opacities[i]
                 ),
                 hovertemplate=(
                     f"Scenario: {scen_name}<br>"
-                    f"Electricity: {elec_em:.1f} {emissions_hover_unit}"
+                    f"Electricity: {elec_em_scaled:,.1f} {emissions_hover_unit}"
                     "<extra></extra>"
                 ),
                 showlegend=show_legend,
@@ -209,12 +226,12 @@ def plot_energy_and_emissions(
         fig.add_trace(
             go.Bar(
                 x=[scen_name_short],
-                y=[gas_em],
+                y=[gas_em_scaled],
                 name="Gas",
                 marker=dict(color=color_map_emissions["Gas"], opacity=opacities[i]),
                 hovertemplate=(
                     f"Scenario: {scen_name}<br>"
-                    f"Gas: {gas_em:.1f} {emissions_hover_unit}"
+                    f"Gas: {gas_em_scaled:,.1f} {emissions_hover_unit}"
                     "<extra></extra>"
                 ),
                 showlegend=show_legend,
@@ -228,14 +245,14 @@ def plot_energy_and_emissions(
         fig.add_trace(
             go.Bar(
                 x=[scen_name_short],
-                y=[refrig_em],
+                y=[refrig_em_scaled],
                 name="Refrigerant",
                 marker=dict(
                     color=color_map_emissions["Refrigerant"], opacity=opacities[i]
                 ),
                 hovertemplate=(
                     f"Scenario: {scen_name}<br>"
-                    f"Refrigerant: {refrig_em:.1f} {emissions_hover_unit}"
+                    f"Refrigerant: {refrig_em_scaled:,.1f} {emissions_hover_unit}"
                     "<extra></extra>"
                 ),
                 showlegend=show_legend,
@@ -264,30 +281,34 @@ def plot_emission_scenarios_grouped(
     emission_scenarios,
     unit_mode="SI",
 ):
-    col_to_type = {
-        "elec_emissions": "emissions",
-        "gas_emissions": "emissions",
-        "total_refrig_emissions": "emissions",
-    }
-
     # --- Filter scenarios ---
     df = df[
         (df["eq_scen_id"].isin(equipment_scenarios))
         & (df["em_scen_id"].isin(emission_scenarios))
     ].copy()
 
-    # --- Unit conversion ---
-    for col in df.columns:
-        if col in col_to_type:
-            var_type = col_to_type[col]
-            conv = get_unit_converter(var_type, unit_mode)  # <- our helper
-            df.loc[:, col] = df[col].apply(conv)
+    # NOTE: Don't use convert_dataframe - we use auto-scaling directly from base units
 
-    # --- Axis label ---
-    yaxis_title_emissions = unit_map["emissions"][unit_mode]["label"]
+    # --- Pre-calculate all emissions totals in BASE units for auto-scaling ---
+    emissions_totals = []
+    for em_scen in emission_scenarios:
+        df_e = df[df["em_scen_id"] == em_scen]
+        for scen in equipment_scenarios:
+            df_s = df_e[df_e["eq_scen_id"] == scen]
+            if not df_s.empty:
+                # Emissions columns are in kg CO₂e (base unit)
+                emissions_totals.append(df_s["elec_emissions"].sum())
+                emissions_totals.append(df_s["gas_emissions"].sum())
+                emissions_totals.append(df_s["total_refrig_emissions"].sum())
 
-    # --- Hover unit ---
-    emissions_hover_unit = get_hover_unit("emissions", unit_mode)
+    # --- Determine auto-scaling (from base units directly) ---
+    emissions_scale, emissions_unit = get_auto_scale(emissions_totals, "emissions", unit_mode)
+
+    # --- Axis label with auto-scaled units ---
+    yaxis_title_emissions = f'Emissions <span style="font-weight:200">| {emissions_unit}</span>'
+
+    # --- Hover unit (use scaled unit) ---
+    emissions_hover_unit = emissions_unit
 
     # --- Colors ---
     color_map_emissions = {
@@ -329,17 +350,22 @@ def plot_emission_scenarios_grouped(
             gas_em = df_s["gas_emissions"].sum()
             refrig_em = df_s["total_refrig_emissions"].sum()
 
+            # Apply auto-scaling
+            elec_em_scaled = elec_em / emissions_scale
+            gas_em_scaled = gas_em / emissions_scale
+            refrig_em_scaled = refrig_em / emissions_scale
+
             # Electricity
             show_legend = "Electricity" not in added_legends
             fig.add_trace(
                 go.Bar(
                     x=[scen_name_short],  # 👈 use name instead of ID
-                    y=[elec_em],
+                    y=[elec_em_scaled],
                     name="Electricity",
                     marker=dict(color=color_map_emissions["Electricity"]),
                     hovertemplate=(
                         f"Equipment: {scen_name}<br>"
-                        f"Electricity: {elec_em:.1f} {emissions_hover_unit}"
+                        f"Electricity: {elec_em_scaled:,.1f} {emissions_hover_unit}"
                         "<extra></extra>"
                     ),
                     showlegend=show_legend,
@@ -354,12 +380,12 @@ def plot_emission_scenarios_grouped(
             fig.add_trace(
                 go.Bar(
                     x=[scen_name_short],
-                    y=[gas_em],
+                    y=[gas_em_scaled],
                     name="Gas",
                     marker=dict(color=color_map_emissions["Gas"]),
                     hovertemplate=(
                         f"Equipment: {scen_name}<br>"
-                        f"Gas: {gas_em:.1f} {emissions_hover_unit}"
+                        f"Gas: {gas_em_scaled:,.1f} {emissions_hover_unit}"
                         "<extra></extra>"
                     ),
                     showlegend=show_legend,
@@ -374,12 +400,12 @@ def plot_emission_scenarios_grouped(
             fig.add_trace(
                 go.Bar(
                     x=[scen_name_short],
-                    y=[refrig_em],
+                    y=[refrig_em_scaled],
                     name="Refrigerant",
                     marker=dict(color=color_map_emissions["Refrigerant"]),
                     hovertemplate=(
                         f"Equipment: {scen_name}<br>"
-                        f"Refrigerant: {refrig_em:.1f} {emissions_hover_unit}"
+                        f"Refrigerant: {refrig_em_scaled:,.1f} {emissions_hover_unit}"
                         "<extra></extra>"
                     ),
                     showlegend=show_legend,
@@ -419,12 +445,9 @@ def plot_meter_timeseries(
     Plot time series data for meters (electricity, gas) with flexible aggregation.
     """
 
-    # Setting up unit conversion
-    variable_type = "energy"
-
     metadata_cols = ["eq_scen_id", "em_scen_id"]
 
-    convert_cols = [
+    energy_cols = [
         "elec_hr_Wh",
         "elec_awhp_h_Wh",
         "elec_chiller_Wh",
@@ -438,17 +461,10 @@ def plot_meter_timeseries(
         & (df["em_scen_id"] == emission_scenario)
     ].copy()
 
-    all_cols = metadata_cols + convert_cols
+    all_cols = metadata_cols + energy_cols
     df = filtered[[c for c in all_cols if c in df.columns]]
 
-    conv = get_unit_converter(variable_type, unit_mode)
-    hover_unit = get_hover_unit(variable_type, unit_mode)
-
-    df.loc[:, [c for c in convert_cols if c in df.columns]] = df[
-        [c for c in convert_cols if c in df.columns]
-    ].apply(conv)
-
-    yaxis_title = unit_map[variable_type][unit_mode]["label"]
+    # NOTE: Don't use convert_dataframe - we use auto-scaling directly from base units
 
     df = df.drop(columns=["eq_scen_id"], errors="ignore")
     df = df.drop(columns=["em_scen_id"], errors="ignore")
@@ -460,7 +476,7 @@ def plot_meter_timeseries(
     if aggfunc not in ["sum", "mean"]:
         raise ValueError("aggfunc must be either 'sum' or 'mean'")
 
-    # Resample data with chosen aggregation
+    # Resample data with chosen aggregation (values remain in base units Wh)
     if aggfunc == "sum":
         df_resampled = df.resample(freq).sum()
         usage_label = "Usage"
@@ -473,6 +489,18 @@ def plot_meter_timeseries(
         df_resampled = df_resampled[
             [col for col in df_resampled.columns if "gas" not in col.lower()]
         ]
+
+    # --- Auto-scaling based on resampled data (in base units Wh) ---
+    all_values = df_resampled.values.flatten()
+    all_values = [v for v in all_values if v is not None and not np.isnan(v)]
+    energy_scale, energy_unit = get_auto_scale(all_values, "energy", unit_mode)
+
+    # Apply scaling to resampled data
+    df_resampled = df_resampled / energy_scale
+
+    # Build axis title with auto-scaled unit
+    yaxis_title = f'Energy <span style="font-weight:200">| {energy_unit}</span>'
+    hover_unit = energy_unit
 
     # Rename columns to user-friendly display names
     df_resampled = df_resampled.rename(columns=format_meter_name)
@@ -508,7 +536,7 @@ def plot_meter_timeseries(
             tr.hovertemplate = (
                 "Time: %{x|%Y-%m-%d %H:%M}<br>"
                 "Meter: %{meta}<br>"
-                f"{usage_label}: " + f"%{{y:.2f}} {hover_unit}"
+                f"{usage_label}: " + f"%{{y:,.2f}} {hover_unit}"
                 "<extra></extra>"
             )
 
@@ -554,7 +582,7 @@ def plot_meter_timeseries(
             tr.hovertemplate = (
                 "Time: %{x|%Y-%m-%d %H:%M}<br>"
                 "Meter: %{meta}<br>"
-                f"{usage_label}: " + f"%{{y:.2f}} {hover_unit}"
+                f"{usage_label}: " + f"%{{y:,.2f}} {hover_unit}"
                 "<extra></extra>"
             )
 
@@ -572,19 +600,16 @@ def plot_emissions_heatmap(
     Plot a heatmap of electricity emissions (elec_emissions) by hour and day of the year.
     """
 
-    # Setting up unit conversion
-    variable_type = "emissions"
-
     metadata_cols = ["eq_scen_id", "em_scen_id"]
 
-    convert_cols = [
+    emission_cols = [
         "elec_emissions",
         "gas_emissions",
         "total_refrig_emissions",
         "total_emissions",
     ]
 
-    all_cols = metadata_cols + convert_cols
+    all_cols = metadata_cols + emission_cols
 
     filtered = df[
         (df["eq_scen_id"] == equipment_scenario)
@@ -594,17 +619,11 @@ def plot_emissions_heatmap(
     # keep only what exists
     df = filtered[[c for c in all_cols if c in filtered.columns]].copy()
 
-    # --- unit conversion (to current mode) ---
-    conv = get_unit_converter(variable_type, unit_mode)
-    hover_unit = get_hover_unit(variable_type, unit_mode)
+    # --- Unit conversion (centralized) ---
+    df = convert_dataframe(df, unit_mode)
 
-    # convert only cols that are present
-    cols_to_convert = [c for c in convert_cols if c in df.columns]
-    if cols_to_convert:
-        df.loc[:, cols_to_convert] = df[cols_to_convert].apply(conv)
-
-    # colorbar / legend title from unit_map (HTML-ish like your other plots)
-    legend_title = unit_map[variable_type][unit_mode]["label"]
+    hover_unit = get_display_unit("emissions", unit_mode)
+    legend_title = unit_map["emissions"][unit_mode]["label"]
 
     # Check if the 'elec_emissions' column exists
     if emission_type not in df.columns:
@@ -683,18 +702,9 @@ def plot_scatter_temp_vs_variable(
         "total_refrig_emissions",
         "total_emissions",
     ]
-    temp_cols = ["t_out_C"]
 
-    # --- Create col_to_type dict dynamically ---
-    col_to_type = {col: "energy" for col in energy_cols}
-    col_to_type.update({col: "emissions" for col in emission_cols})
-    col_to_type.update({col: "temperature" for col in temp_cols})
-
-    # --- Convert units if needed ---
-    for col, var_type in col_to_type.items():
-        if col in df.columns:
-            conv = get_unit_converter(var_type, unit_mode)
-            df[col] = df[col].apply(conv)
+    # --- Unit conversion (centralized) ---
+    df = convert_dataframe(df, unit_mode)
 
     # --- Determine y-axis type and label ---
     if y_var not in df.columns:
@@ -711,8 +721,8 @@ def plot_scatter_temp_vs_variable(
     xaxis_title_temp = unit_map["temperature"][unit_mode]["label"]
 
     # hover units (short, plain text)
-    y_hover_unit = get_hover_unit(y_var_type, unit_mode)
-    t_hover_unit = get_hover_unit("temperature", unit_mode)
+    y_hover_unit = get_display_unit(y_var_type, unit_mode)
+    t_hover_unit = get_display_unit("temperature", unit_mode)
 
     # --- Filter scenarios ---
     df = df[

--- a/src/visuals.py
+++ b/src/visuals.py
@@ -669,10 +669,19 @@ def plot_emissions_heatmap(
         template="decarb-tool-theme",
     )
 
+    # Map emission type to display name
+    emission_type_labels = {
+        "elec_emissions": "Electricity Emissions",
+        "gas_emissions": "Gas Emissions",
+        "total_refrig_emissions": "Refrigerant Emissions",
+        "total_emissions": "Total Emissions",
+    }
+    emission_label = emission_type_labels.get(emission_type, emission_type)
+
     fig = apply_standard_layout(
         fig,
         y_offset=-0.3,
-        subtitle_text=f"Annual heatmap of hourly emissions for {emission_type}.",
+        subtitle_text=f"Annual heatmap of hourly {emission_label.lower()}.",
     )
 
     return fig

--- a/src/visuals.py
+++ b/src/visuals.py
@@ -5,6 +5,7 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from utils.units import unit_map, get_unit_converter, get_hover_unit
+from utils.display_registry import format_emission_scenario_id, format_meter_name
 
 
 # colors
@@ -300,7 +301,9 @@ def plot_emission_scenarios_grouped(
     fig = make_subplots(
         rows=1,
         cols=n_em_scen,
-        subplot_titles=[f"{em_scen}" for em_scen in emission_scenarios],
+        subplot_titles=[
+            format_emission_scenario_id(em_scen) for em_scen in emission_scenarios
+        ],
         horizontal_spacing=0.12,
         shared_yaxes=True,
     )
@@ -470,6 +473,9 @@ def plot_meter_timeseries(
         df_resampled = df_resampled[
             [col for col in df_resampled.columns if "gas" not in col.lower()]
         ]
+
+    # Rename columns to user-friendly display names
+    df_resampled = df_resampled.rename(columns=format_meter_name)
 
     if not stacked:
 

--- a/utils/display_registry.py
+++ b/utils/display_registry.py
@@ -1,0 +1,114 @@
+"""Central registry for mapping raw IDs to user-friendly display names."""
+
+from src.equipment import load_library
+
+
+class DisplayRegistry:
+    """Central registry for mapping raw IDs to display names."""
+
+    _equipment_lookup: dict = None
+
+    @classmethod
+    def get_equipment_name(cls, eq_id: str) -> str:
+        """Map equipment ID to model name.
+
+        Args:
+            eq_id: The equipment ID (e.g., "hr01", "awhp_1", "b01")
+
+        Returns:
+            The equipment model name, or the original ID if not found
+        """
+        if eq_id is None:
+            return None
+        if cls._equipment_lookup is None:
+            cls._build_equipment_lookup()
+        return cls._equipment_lookup.get(eq_id, eq_id)
+
+    @classmethod
+    def _build_equipment_lookup(cls):
+        """Build the equipment ID to model name lookup dictionary."""
+        library = load_library("data/input/equipment_data.JSON")
+        cls._equipment_lookup = {eq.eq_id: eq.model for eq in library.equipment}
+
+    @classmethod
+    def clear_cache(cls):
+        """Clear the cached lookup dictionary (useful for testing)."""
+        cls._equipment_lookup = None
+
+
+# Convenience function for use in table formatting
+def get_equipment_display_name(eq_id: str) -> str:
+    """Get the display name for an equipment ID.
+
+    Args:
+        eq_id: The equipment ID (e.g., "hr01", "awhp_1", "b01")
+
+    Returns:
+        The equipment model name, or the original ID if not found
+    """
+    return DisplayRegistry.get_equipment_name(eq_id)
+
+
+# Fields that contain equipment IDs and should be mapped to model names
+EQUIPMENT_ID_FIELDS = frozenset({"hr_wwhp", "awhp", "backup_heating", "chiller"})
+
+
+def format_equipment_scenario_id(eq_scen_id: str) -> str:
+    """Format equipment scenario ID for display.
+
+    Args:
+        eq_scen_id: The scenario ID (e.g., "eq_scenario_1", "eq_scenario_2")
+
+    Returns:
+        Formatted display name (e.g., "Equipment Scen. 1")
+    """
+    if eq_scen_id is None:
+        return None
+    # Expected format: "eq_scenario_X" where X is a number
+    if eq_scen_id.startswith("eq_scenario_"):
+        suffix = eq_scen_id[len("eq_scenario_") :]
+        return f"Equipment Scen. {suffix}"
+    return eq_scen_id
+
+
+def format_emission_scenario_id(em_scen_id: str) -> str:
+    """Format emission scenario ID for display.
+
+    Args:
+        em_scen_id: The scenario ID (e.g., "em_scenario_a", "em_scenario_b")
+
+    Returns:
+        Formatted display name (e.g., "Emission Scen. A")
+    """
+    if em_scen_id is None:
+        return None
+    # Expected format: "em_scenario_X" where X is a letter
+    if em_scen_id.startswith("em_scenario_"):
+        suffix = em_scen_id[len("em_scenario_") :]
+        return f"Emission Scen. {suffix.upper()}"
+    return em_scen_id
+
+
+# Mapping of meter/variable column names to user-friendly display names
+METER_DISPLAY_NAMES = {
+    # Electricity meters
+    "elec_hr_Wh": "HR-WWHP Elec.",
+    "elec_awhp_h_Wh": "AWHP Heating Elec.",
+    "elec_awhp_c_Wh": "AWHP Cooling Elec.",
+    "elec_chiller_Wh": "Chiller Elec.",
+    "elec_res_Wh": "Resistance Heater Elec.",
+    # Gas meters
+    "gas_boiler_Wh": "Boiler Gas",
+}
+
+
+def format_meter_name(meter_col: str) -> str:
+    """Format a meter column name for display.
+
+    Args:
+        meter_col: The column name (e.g., "elec_hr_Wh", "gas_boiler_Wh")
+
+    Returns:
+        User-friendly display name (e.g., "HR-WWHP Elec.", "Boiler Gas")
+    """
+    return METER_DISPLAY_NAMES.get(meter_col, meter_col)

--- a/utils/display_registry.py
+++ b/utils/display_registry.py
@@ -52,6 +52,35 @@ def get_equipment_display_name(eq_id: str) -> str:
 # Fields that contain equipment IDs and should be mapped to model names
 EQUIPMENT_ID_FIELDS = frozenset({"hr_wwhp", "awhp", "backup_heating", "chiller"})
 
+# AWHP sizing mode value mappings
+AWHP_SIZING_MODE_DISPLAY = {
+    "integer_sizing_peak_load": "Integer sizing (peak load)",
+    "fractional_sizing_peak_load": "Fractional sizing (peak load)",
+    "fixed_num_units": "Fixed number of units",
+}
+
+# Fields that have enumerated values needing display mapping
+ENUM_VALUE_FIELDS = frozenset({"awhp_sizing_mode"})
+
+
+def format_enum_value(value: str, field_name: str) -> str:
+    """Format enumerated field values for display.
+
+    Args:
+        value: The raw enum value
+        field_name: The field name to determine which mapping to use
+
+    Returns:
+        User-friendly display name
+    """
+    if value is None:
+        return None
+
+    if field_name == "awhp_sizing_mode":
+        return AWHP_SIZING_MODE_DISPLAY.get(value, value)
+
+    return value
+
 
 def format_equipment_scenario_id(eq_scen_id: str) -> str:
     """Format equipment scenario ID for display.

--- a/utils/error_handling.py
+++ b/utils/error_handling.py
@@ -96,3 +96,21 @@ def create_success_notification(
         "autoClose": 3000,
         "icon": DashIconify(icon="mdi:check-circle-outline"),
     }
+
+
+def create_info_notification(
+    title: str,
+    message: str,
+    notification_id: str = "info-notification",
+) -> dict:
+    """Create a Mantine notification for informational messages (blue)."""
+    return {
+        "id": notification_id,
+        "title": title,
+        "message": message,
+        "color": "blue",
+        "loading": False,
+        "action": "show",
+        "autoClose": 3000,
+        "icon": DashIconify(icon="mdi:information-outline"),
+    }

--- a/utils/units.py
+++ b/utils/units.py
@@ -103,142 +103,672 @@ def sqm_to_sqft(sqm):
     return sqm * 10.7639
 
 
-### MAPPING FOR CHARTS ###
-unit_map = {
+### CENTRALIZED UNIT CONVERSION SYSTEM ###
+# This is the single source of truth for all unit conversions in the app.
+# See docs/unit-conventions.md for full documentation.
+
+# =============================================================================
+# UNIT_MAP: Category-based unit definitions with base/SI/IP
+# =============================================================================
+# Structure: category -> {base, SI: {unit, func}, IP: {unit, func}}
+# - base: internal storage unit (used in calculations)
+# - SI: {unit: display label, func: base→SI conversion}
+# - IP: {unit: display label, func: base→IP conversion}
+
+UNIT_MAP = {
+    # --- Energy (heating & general) ---
     "energy": {
-        "SI": {
-            "func": Wh_to_kWh,
-            "label": 'Energy <span style="font-weight:200">| kWh</span>',
-            "hover_unit": "kWh",
-        },
-        "IP": {
-            "func": Wh_to_BTUh,
-            "label": 'Energy <span style="font-weight:200">| BTU</span>',
-            "hover_unit": "BTU",
-        },
+        "base": "Wh",
+        "SI": {"unit": "kWh", "func": Wh_to_kWh},
+        "IP": {"unit": "BTU", "func": Wh_to_BTUh},
     },
-    "temperature": {
-        "SI": {
-            "func": lambda x: x,
-            "label": 'Temperature <span style="font-weight:200">| °C</span>',
-            "hover_unit": "°C",
-        },
-        "IP": {
-            "func": C_to_F,
-            "label": 'Temperature <span style="font-weight:200">| °F</span>',
-            "hover_unit": "°F",
-        },
-    },
-    "emissions": {
-        "SI": {
-            "func": lambda x: x,
-            "label": 'Emissions <span style="font-weight:200">| kgCO₂e</span>',
-            "hover_unit": "kgCO₂e",
-        },
-        "IP": {
-            "func": kg_to_lbs,
-            "label": 'Emissions <span style="font-weight:200">| lbCO₂e</span>',
-            "hover_unit": "lbCO₂e",
-        },
-    },
-    "gas_emission_factor": {
-        "SI": {
-            "label": "gCO₂e/kWh",
-            "func": lambda x: (x * lb_to_g / BTU_to_Wh),  # gCO₂e/kWh → lbCO₂e/kBTU
-            "default_value": 239.2 / (lb_to_g / BTU_to_Wh),  #! use function
-        },
-        "IP": {
-            "label": "lbCO₂e/kBTU",
-            "func": lambda x: (x * g_to_lb / Wh_to_BTU),  # lbCO₂e/kBTU → gCO₂e/kWh
-            "default_value": 0.15455 / (g_to_lb / Wh_to_BTU),  #! use function
-        },
-    },
+    # --- Power (heating & general) ---
     "power": {
-        "SI": {
-            "func": W_to_kW,
-            "label": "Power (kW)",
-            "hover_unit": "kW",
-            "short": "kW",
-        },
-        "IP": {
-            "func": W_to_tons,
-            "label": "Power (tons)",
-            "hover_unit": "tons",
-            "short": "tons",
-        },
+        "base": "W",
+        "SI": {"unit": "kW", "func": W_to_kW},
+        "IP": {"unit": "BTU/h", "func": lambda x: x * W_to_BTUh},
     },
-    "area": {
-        "SI": {
-            "func": lambda x: x,
-            "label": "Area (m²)",
-            "hover_unit": "m²",
-            "short": "m²",
-        },
-        "IP": {
-            "func": sqm_to_sqft,
-            "label": "Area (ft²)",
-            "hover_unit": "ft²",
-            "short": "ft²",
-        },
+    # --- Power for cooling (uses tons of refrigeration in IP) ---
+    "power_cooling": {
+        "base": "W",
+        "SI": {"unit": "kW", "func": W_to_kW},
+        "IP": {"unit": "TR", "func": W_to_tons},
     },
+    # --- Capacity (same as power, for equipment ratings) ---
+    "capacity": {
+        "base": "W",
+        "SI": {"unit": "kW", "func": W_to_kW},
+        "IP": {"unit": "BTU/h", "func": lambda x: x * W_to_BTUh},
+    },
+    # --- Capacity for cooling equipment ---
+    "capacity_cooling": {
+        "base": "W",
+        "SI": {"unit": "kW", "func": W_to_kW},
+        "IP": {"unit": "TR", "func": W_to_tons},
+    },
+    # --- Power already in kW (for pre-converted data) ---
     "power_kw": {
-        # For data already in kW (e.g., load summaries)
-        "SI": {
-            "func": lambda x: x,
-            "label": "Power (kW)",
-            "hover_unit": "kW",
-            "short": "kW",
-        },
-        "IP": {
-            "func": kW_to_tons,
-            "label": "Power (tons)",
-            "hover_unit": "tons",
-            "short": "tons",
-        },
+        "base": "kW",
+        "SI": {"unit": "kW", "func": lambda x: x},
+        "IP": {"unit": "TR", "func": kW_to_tons},
     },
+    # --- Temperature ---
+    "temperature": {
+        "base": "°C",
+        "SI": {"unit": "°C", "func": lambda x: x},
+        "IP": {"unit": "°F", "func": C_to_F},
+    },
+    # --- Area ---
+    "area": {
+        "base": "m²",
+        "SI": {"unit": "m²", "func": lambda x: x},
+        "IP": {"unit": "ft²", "func": sqm_to_sqft},
+    },
+    # --- Emissions (mass of CO2e) ---
+    "emissions": {
+        "base": "kg CO₂e",
+        "SI": {"unit": "kg CO₂e", "func": lambda x: x},
+        "IP": {"unit": "lb CO₂e", "func": kg_to_lbs},
+    },
+    # --- Emission rate (grid emissions) ---
+    "emissions_rate": {
+        "base": "g CO₂e/kWh",
+        "SI": {"unit": "g CO₂e/kWh", "func": lambda x: x},
+        "IP": {"unit": "lb CO₂e/kBTU", "func": lambda x: x * g_to_lb / Wh_to_BTU},
+    },
+    # --- Gas emission factor ---
+    "gas_emission_factor": {
+        "base": "g CO₂e/kWh",
+        "SI": {"unit": "g CO₂e/kWh", "func": lambda x: x},
+        "IP": {"unit": "lb CO₂e/kBTU", "func": lambda x: x * g_to_lb / Wh_to_BTU},
+    },
+    # --- NG leakage rate ---
     "ng_leakage_rate": {
-        # For NG leakage rate (stored in g/kWh)
-        "SI": {
-            "func": lambda x: x,
-            "label": "NG leakage (g/kWh)",
-            "hover_unit": "g/kWh",
-            "short": "g/kWh",
-        },
-        "IP": {
-            # Convert g/kWh to lb/kBTU: divide by 454 (g→lb), divide by 3.412 (kWh→kBTU)
-            "func": lambda x: x * g_to_lb / Wh_to_BTU,
-            "label": "NG leakage (lb/kBTU)",
-            "hover_unit": "lb/kBTU",
-            "short": "lb/kBTU",
-        },
+        "base": "g/kWh",
+        "SI": {"unit": "g/kWh", "func": lambda x: x},
+        "IP": {"unit": "lb/kBTU", "func": lambda x: x * g_to_lb / Wh_to_BTU},
+    },
+    # --- Mass (refrigerant weight, etc.) ---
+    "mass": {
+        "base": "kg",
+        "SI": {"unit": "kg", "func": lambda x: x},
+        "IP": {"unit": "lb", "func": kg_to_lbs},
+    },
+    # --- Mass stored in grams ---
+    "mass_g": {
+        "base": "g",
+        "SI": {"unit": "kg", "func": lambda x: x / 1000},
+        "IP": {"unit": "lb", "func": lambda x: x * g_to_lb},
+    },
+    # --- Load intensity ---
+    "load_intensity": {
+        "base": "W/m²",
+        "SI": {"unit": "W/m²", "func": lambda x: x},
+        "IP": {"unit": "BTU/h·ft²", "func": lambda x: x * W_to_BTUh / 10.7639},
+    },
+    # --- GWP (global warming potential per kg refrigerant) ---
+    "gwp": {
+        "base": "kg CO₂e/kg",
+        "SI": {"unit": "kg CO₂e/kg", "func": lambda x: x},
+        "IP": {"unit": "lb CO₂e/lb", "func": lambda x: x},  # dimensionless ratio
     },
 }
 
 
+# =============================================================================
+# COLUMN_CONFIG: Unified registry for column metadata (SINGLE SOURCE OF TRUTH)
+# =============================================================================
+# Each entry: column_name -> (category, display_name)
+# - category: Unit category from UNIT_MAP (or None for dimensionless)
+# - display_name: Human-readable label for exports/display
+#
+# Add new columns here when they're added to calculations.
+
+COLUMN_CONFIG = {
+    # === Area ===
+    "area_sqm": ("area", "Area"),
+    # === Energy (Wh) ===
+    "elec_Wh": ("energy", "Total Electricity"),
+    "gas_Wh": ("energy", "Total Gas"),
+    "elec_hr_Wh": ("energy", "HR-WWHP Electricity"),
+    "elec_awhp_h_Wh": ("energy", "AWHP Heating Electricity"),
+    "elec_awhp_c_Wh": ("energy", "AWHP Cooling Electricity"),
+    "elec_res_Wh": ("energy", "Resistance Heater Electricity"),
+    "elec_chiller_Wh": ("energy", "Chiller Electricity"),
+    "gas_boiler_Wh": ("energy", "Boiler Gas"),
+    # === Power - Heating (W) ===
+    "heating_W": ("power", "Heating Load"),
+    "hhw_W": ("power", "HHW Load"),
+    "hhw_rem_W": ("power", "HHW Remaining"),
+    "hr_hhw_W": ("power", "HR HHW Output"),
+    "awhp_hhw_W": ("power", "AWHP HHW Output"),
+    "boiler_hhw_W": ("power", "Boiler HHW Output"),
+    "res_hhw_W": ("power", "Resistance HHW Output"),
+    "hhw_max_load": ("power", "Peak HHW Load"),
+    "hhw_mean_load": ("power", "Mean HHW Load"),
+    "hhw_median_load": ("power", "Median HHW Load"),
+    "hhw_min_load": ("power", "Min HHW Load"),
+    "hhw_q25_load": ("power", "Q25 HHW Load"),
+    "hhw_q75_load": ("power", "Q75 HHW Load"),
+    # === Power - Cooling (W) ===
+    "cooling_W": ("power_cooling", "Cooling Load"),
+    "chw_W": ("power_cooling", "CHW Load"),
+    "chw_rem_W": ("power_cooling", "CHW Remaining"),
+    "hr_chw_W": ("power_cooling", "HR CHW Output"),
+    "awhp_chw_W": ("power_cooling", "AWHP CHW Output"),
+    "chiller_chw_W": ("power_cooling", "Chiller CHW Output"),
+    "chw_max_load": ("power_cooling", "Peak CHW Load"),
+    "chw_mean_load": ("power_cooling", "Mean CHW Load"),
+    "chw_median_load": ("power_cooling", "Median CHW Load"),
+    "chw_min_load": ("power_cooling", "Min CHW Load"),
+    "chw_q25_load": ("power_cooling", "Q25 CHW Load"),
+    "chw_q75_load": ("power_cooling", "Q75 CHW Load"),
+    # === Capacity - Heating (W) ===
+    "max_cap_h_hr_W": ("capacity", "HR Max Heating Cap"),
+    "min_cap_h_hr_W": ("capacity", "HR Min Heating Cap"),
+    "simult_h_hr_W": ("capacity", "HR Simultaneous Cap"),
+    "awhp_cap_h_W": ("capacity", "AWHP Heating Cap"),
+    "capacity_W": ("capacity", "Rated Capacity"),
+    # === Capacity - Cooling (W) ===
+    "awhp_cap_c_W": ("capacity_cooling", "AWHP Cooling Cap"),
+    # === Temperature (°C) ===
+    "t_out_C": ("temperature", "Outdoor Temp"),
+    "max_temp": ("temperature", "Max Temp"),
+    "min_temp": ("temperature", "Min Temp"),
+    "median_temp": ("temperature", "Median Temp"),
+    # === Load Intensity (W/m²) ===
+    "hhw_max_load_per_area": ("load_intensity", "Peak HHW Load/Area"),
+    "chw_max_load_per_area": ("load_intensity", "Peak CHW Load/Area"),
+    # === Emissions (kg CO₂e) ===
+    "elec_emissions": ("emissions", "Electricity Emissions"),
+    "gas_emissions": ("emissions", "Gas Emissions"),
+    "total_refrig_emissions": ("emissions", "Refrigerant Emissions"),
+    "total_emissions": ("emissions", "Total Emissions"),
+    "total_refrig_gwp_kg": ("emissions", "Total Refrigerant GWP"),
+    # === Emission Rates (g CO₂e/kWh) ===
+    "elec_emissions_rate_gCO2e_per_kWh": ("emissions_rate", "Elec Emissions Rate"),
+    "lrmer_co2e_c": ("emissions_rate", "LRMER Combustion"),
+    "lrmer_co2e_p": ("emissions_rate", "LRMER Pre-combustion"),
+    "srmer_co2e_c": ("emissions_rate", "SRMER Combustion"),
+    "srmer_co2e_p": ("emissions_rate", "SRMER Pre-combustion"),
+    # === NG Leakage ===
+    "annual_ng_leakage_g_per_kWh": ("ng_leakage_rate", "Annual NG Leakage"),
+    # === Refrigerant Mass (kg) ===
+    "hr_wwhp_refrigerant_weight_kg": ("mass", "HR-WWHP Refrig Weight"),
+    "total_awhp_refrigerant_weight_kg": ("mass", "AWHP Refrig Weight"),
+    "chiller_refrigerant_weight_kg": ("mass", "Chiller Refrig Weight"),
+    # === Refrigerant Mass (g) ===
+    "refrigerant_weight_g": ("mass_g", "Refrigerant Charge"),
+    # === Refrigerant GWP ===
+    "hr_wwhp_refrigerant_gwp_kgCO2e_per_kgRefrig": ("gwp", "HR-WWHP Refrig GWP"),
+    "total_awhp_refrigerant_gwp_kgCO2e_per_kgRefrig": ("gwp", "AWHP Refrig GWP"),
+    "chiller_refrigerant_gwp_kgCO2e_per_kgRefrig": ("gwp", "Chiller Refrig GWP"),
+    # === COP / Efficiency (dimensionless - no unit conversion needed) ===
+    "hr_cop_h": (None, "HR Heating COP"),
+    "awhp_cop_h": (None, "AWHP Heating COP"),
+    "awhp_cop_c": (None, "AWHP Cooling COP"),
+    "chiller_cop": (None, "Chiller COP"),
+    "boiler_eff": (None, "Boiler Efficiency"),
+    # === Equipment Counts (dimensionless) ===
+    "awhp_num_h": (None, "AWHP Count (Heating)"),
+    "awhp_num_h_redundant": (None, "AWHP Redundant (Heating)"),
+    "awhp_num_c": (None, "AWHP Count (Cooling)"),
+    # === Refrigerant Type (text - no conversion) ===
+    "chiller_refrigerant": (None, "Chiller Refrigerant"),
+    "hr_wwhp_refrigerant": (None, "HR-WWHP Refrigerant"),
+    "awhp_refrigerant": (None, "AWHP Refrigerant"),
+    # === Emission Scenario Parameters ===
+    "lrmer_co2e": (None, "LRMER CO₂e"),
+    "srmer_co2e": (None, "SRMER CO₂e"),
+    "shortrun_weighting": (None, "Short-run Weighting"),
+    "year": (None, "Year"),
+    # === Scenario Identifiers ===
+    "em_scen_id": (None, "Emission Scenario ID"),
+    "eq_scen_id": (None, "Equipment Scenario ID"),
+    "eq_scen_name": (None, "Equipment Scenario"),
+}
+
+
+# =============================================================================
+# DERIVED VIEWS (for backward compatibility)
+# =============================================================================
+# These are derived from COLUMN_CONFIG to maintain backward compatibility.
+# New code should use COLUMN_CONFIG or the helper functions.
+
+COLUMN_REGISTRY = {
+    col: config[0]
+    for col, config in COLUMN_CONFIG.items()
+    if config[0] is not None
+}
+
+COLUMN_DISPLAY_NAMES = {
+    col: config[1]
+    for col, config in COLUMN_CONFIG.items()
+}
+
+
+# =============================================================================
+# AUTO-SCALING: Higher-order unit configuration for large values
+# =============================================================================
+# Defines scaling thresholds and higher-order units for categories.
+# Used when accumulated values become too large to display readably.
+
+AUTO_SCALE_CONFIG = {
+    # Thresholds are in BASE units (W, Wh, kg, etc.)
+    # Scale factors convert directly from base to the target display unit.
+    # Format: (threshold_in_base, scale_factor, unit_label)
+    "energy": {
+        "SI": [
+            (1e9, 1e9, "GWh"),   # >= 1 GWh (in Wh) → GWh
+            (1e6, 1e6, "MWh"),   # >= 1 MWh (in Wh) → MWh
+            (1e3, 1e3, "kWh"),   # >= 1 kWh (in Wh) → kWh
+        ],
+        "IP": [
+            # 1 Wh = 3.412 BTU; MMBTU = 1e6 BTU
+            # Threshold: 1 MMBTU = 1e6 BTU = 1e6/3.412 Wh ≈ 293,083 Wh
+            # Scale: divide Wh by (1e6/3.412) to get MMBTU
+            (1e6 / 3.412, 1e6 / 3.412, "MMBTU"),
+            (1e3 / 3.412, 1e3 / 3.412, "kBTU"),
+        ],
+    },
+    "power": {
+        "SI": [
+            (1e6, 1e6, "MW"),    # >= 1 MW (in W) → MW
+            (1e3, 1e3, "kW"),    # >= 1 kW (in W) → kW
+        ],
+        "IP": [
+            # 1 W = 3.412 BTU/h; MMBTU/h = 1e6 BTU/h
+            # Threshold: 1 MMBTU/h = 1e6/3.412 W ≈ 293,083 W
+            (1e6 / 3.412, 1e6 / 3.412, "MMBTU/h"),
+            (1e3 / 3.412, 1e3 / 3.412, "kBTU/h"),
+        ],
+    },
+    "power_cooling": {
+        "SI": [
+            (1e6, 1e6, "MW"),
+            (1e3, 1e3, "kW"),
+        ],
+        "IP": [
+            # 1 TR = 3517 W
+            (3517 * 1e3, 3517 * 1e3, "kTR"),  # >= 1000 TR
+            (3517, 3517, "TR"),               # >= 1 TR
+        ],
+    },
+    "emissions": {
+        "SI": [
+            (1e6, 1e6, "kt CO₂e"),  # >= 1 kilotonne (in kg) → kt
+            (1e3, 1e3, "t CO₂e"),   # >= 1 tonne (in kg) → t
+        ],
+        "IP": [
+            # EPA convention: use metric tons
+            (1e3, 1e3, "t CO₂e"),  # >= 1 metric ton (in kg) → t
+        ],
+    },
+}
+
+
+# =============================================================================
+# BACKWARD COMPATIBILITY: Legacy unit_map format
+# =============================================================================
+# This maintains compatibility with existing code that uses the old format.
+# New code should use UNIT_MAP and the new helper functions.
+
+def _build_legacy_unit_map():
+    """Build backward-compatible unit_map from new UNIT_MAP structure."""
+    legacy = {}
+    for category, config in UNIT_MAP.items():
+        legacy[category] = {}
+        for mode in ["SI", "IP"]:
+            mode_config = config[mode]
+            base_unit = config["base"]
+            display_unit = mode_config["unit"]
+
+            legacy[category][mode] = {
+                "func": mode_config["func"],
+                "label": f'{category.replace("_", " ").title()} <span style="font-weight:200">| {display_unit}</span>',
+                "hover_unit": display_unit,
+                "short": display_unit,
+            }
+    return legacy
+
+unit_map = _build_legacy_unit_map()
+
+
+# =============================================================================
+# NEW HELPER FUNCTIONS (recommended for new code)
+# =============================================================================
+
+
+def get_category(column_name: str) -> str | None:
+    """Look up the unit category for a column name.
+
+    Args:
+        column_name: The column/field name (e.g., "elec_Wh", "t_out_C")
+
+    Returns:
+        Category string (e.g., "energy", "temperature") or None if not registered
+    """
+    return COLUMN_REGISTRY.get(column_name)
+
+
+def get_converter(category: str, unit_mode: str):
+    """Get conversion function for category and mode.
+
+    Args:
+        category: Unit category (e.g., "energy", "power", "temperature")
+        unit_mode: "SI" or "IP"
+
+    Returns:
+        Conversion function that takes a value and returns converted value
+    """
+    return UNIT_MAP[category][unit_mode]["func"]
+
+
+def get_display_unit(category: str, unit_mode: str) -> str:
+    """Get display unit label for category and mode.
+
+    Args:
+        category: Unit category (e.g., "energy", "power")
+        unit_mode: "SI" or "IP"
+
+    Returns:
+        Unit string (e.g., "kWh", "BTU", "°F")
+    """
+    return UNIT_MAP[category][unit_mode]["unit"]
+
+
+def get_base_unit(category: str) -> str:
+    """Get the base (internal storage) unit for a category.
+
+    Args:
+        category: Unit category (e.g., "energy", "power")
+
+    Returns:
+        Base unit string (e.g., "Wh", "W", "°C")
+    """
+    return UNIT_MAP[category]["base"]
+
+
+def convert_value(value, column_name: str, unit_mode: str):
+    """Convert a single value based on column name and unit mode.
+
+    Args:
+        value: Raw value in base units
+        column_name: Column/field name to look up category
+        unit_mode: "SI" or "IP"
+
+    Returns:
+        Converted value, or original value if column not registered
+    """
+    if value is None:
+        return None
+
+    category = get_category(column_name)
+    if category is None:
+        return value
+
+    converter = get_converter(category, unit_mode)
+    return converter(value)
+
+
+def convert_dataframe(df, unit_mode: str):
+    """Convert all registered columns in a DataFrame.
+
+    Args:
+        df: pandas DataFrame with columns to convert
+        unit_mode: "SI" or "IP"
+
+    Returns:
+        New DataFrame with converted values (original is not modified)
+    """
+    import pandas as pd
+
+    df = df.copy()
+    for col in df.columns:
+        category = get_category(col)
+        if category is not None:
+            converter = get_converter(category, unit_mode)
+            # Handle potential NaN values
+            df[col] = df[col].apply(lambda x: converter(x) if pd.notna(x) else x)
+    return df
+
+
+def get_column_display_name(column_name: str) -> str:
+    """Get human-readable display name for a column.
+
+    Args:
+        column_name: Column/field name
+
+    Returns:
+        Human-readable name, or original if not found
+    """
+    return COLUMN_DISPLAY_NAMES.get(column_name, column_name)
+
+
+def get_column_label(column_name: str, unit_mode: str) -> str:
+    """Get display label for column including unit.
+
+    Args:
+        column_name: Column/field name
+        unit_mode: "SI" or "IP"
+
+    Returns:
+        Label with unit, e.g., "Peak HHW Load [kW]"
+    """
+    display_name = get_column_display_name(column_name)
+    category = get_category(column_name)
+
+    if category is None:
+        return display_name
+
+    unit = get_display_unit(category, unit_mode)
+    return f"{display_name} [{unit}]"
+
+
+def format_value(value, column_name: str, unit_mode: str, decimals: int = 1) -> str:
+    """Format a value with conversion and appropriate decimal places.
+
+    Args:
+        value: Raw value in base units
+        column_name: Column/field name
+        unit_mode: "SI" or "IP"
+        decimals: Number of decimal places
+
+    Returns:
+        Formatted string (e.g., "1,234.5")
+    """
+    if value is None:
+        return "—"
+
+    converted = convert_value(value, column_name, unit_mode)
+    if converted is None:
+        return "—"
+
+    try:
+        return f"{converted:,.{decimals}f}"
+    except (TypeError, ValueError):
+        return str(converted)
+
+
+# =============================================================================
+# AUTO-SCALING FUNCTIONS (for large accumulated values)
+# =============================================================================
+
+
+def get_auto_scale(values, category: str, unit_mode: str):
+    """Determine the appropriate scale for a series of values in BASE units.
+
+    Analyzes the maximum value and selects an appropriate display unit,
+    returning the scale factor to convert from base to that unit.
+
+    Args:
+        values: Iterable of numeric values in BASE units (W, Wh, kg, etc.)
+        category: Unit category (e.g., "energy", "power", "emissions")
+        unit_mode: "SI" or "IP"
+
+    Returns:
+        Tuple of (scale_factor, unit_label) where:
+        - scale_factor: Divide base unit values by this to get display values
+        - unit_label: The unit string to display (e.g., "MW", "kBTU/h")
+
+    Example:
+        >>> values = [1200000, 800000, 1500000]  # Values in W
+        >>> scale, unit = get_auto_scale(values, "power", "SI")
+        >>> print(scale, unit)  # 1000, "kW" (or 1000000, "MW" if larger)
+        >>> display_values = [v / scale for v in values]
+    """
+    if category not in AUTO_SCALE_CONFIG:
+        # No auto-scaling configured - use standard conversion
+        return 1, get_display_unit(category, unit_mode)
+
+    mode_config = AUTO_SCALE_CONFIG[category].get(unit_mode, [])
+    if not mode_config:
+        return 1, get_display_unit(category, unit_mode)
+
+    # Find the maximum absolute value
+    try:
+        max_val = max(abs(v) for v in values if v is not None and v == v)  # v == v filters NaN
+    except (ValueError, TypeError):
+        # Empty or invalid values
+        return 1, get_display_unit(category, unit_mode)
+
+    # Find the appropriate scale based on thresholds (in base units)
+    for threshold, scale_factor, unit in mode_config:
+        if max_val >= threshold:
+            return scale_factor, unit
+
+    # If no threshold matched, use the last (smallest) entry as default
+    # This ensures proper unit conversion even for small values
+    if mode_config:
+        _, scale_factor, unit = mode_config[-1]
+        return scale_factor, unit
+
+    # Fallback if no config at all
+    return 1, get_display_unit(category, unit_mode)
+
+
+def auto_scale_series(values, category: str, unit_mode: str):
+    """Auto-scale a series of values from base units to appropriate display units.
+
+    Takes values in base units (W, Wh, kg) and returns scaled values with
+    the appropriate display unit label.
+
+    Args:
+        values: Iterable of values in BASE units (W, Wh, kg, etc.)
+        category: Unit category
+        unit_mode: "SI" or "IP"
+
+    Returns:
+        Tuple of (scaled_values, unit_label) where:
+        - scaled_values: List of scaled values ready for display
+        - unit_label: Unit string to use in axis labels/legends
+
+    Example:
+        >>> values = [1500000, 800000, 1200000]  # W
+        >>> scaled, unit = auto_scale_series(values, "power", "SI")
+        >>> print(scaled, unit)  # [1500, 800, 1200], "kW"
+    """
+    # Determine scale directly from base unit values
+    scale_factor, unit = get_auto_scale(values, category, unit_mode)
+
+    # Apply scaling
+    scaled = [v / scale_factor if v is not None else None for v in values]
+    return scaled, unit
+
+
+def get_scaled_axis_label(category: str, unit_mode: str, max_value: float = None) -> str:
+    """Get an axis label with auto-scaled unit based on data range.
+
+    Args:
+        category: Unit category (e.g., "energy", "power")
+        unit_mode: "SI" or "IP"
+        max_value: Maximum value in the data (in display units, after base conversion)
+                   If None, returns the standard unit label.
+
+    Returns:
+        Axis label with appropriate unit (e.g., "Energy [MWh]", "Power [kW]")
+    """
+    if max_value is None:
+        unit = get_display_unit(category, unit_mode)
+    else:
+        # Use the max value to determine scale
+        _, unit = get_auto_scale([max_value], category, unit_mode)
+
+    # Create a nice category label
+    category_label = category.replace("_", " ").title()
+    if category == "power_cooling":
+        category_label = "Power"
+    elif category == "capacity_cooling":
+        category_label = "Capacity"
+
+    return f"{category_label} [{unit}]"
+
+
+def format_large_number(n: float, decimals: int = 1) -> str:
+    """Format a large number with appropriate suffix (k, M, G).
+
+    Args:
+        n: Number to format
+        decimals: Decimal places for the formatted number
+
+    Returns:
+        Formatted string (e.g., "1.2M", "345k", "789")
+    """
+    if n is None:
+        return "—"
+
+    abs_n = abs(n)
+    if abs_n >= 1e9:
+        return f"{n / 1e9:.{decimals}f}G"
+    elif abs_n >= 1e6:
+        return f"{n / 1e6:.{decimals}f}M"
+    elif abs_n >= 1e3:
+        return f"{n / 1e3:.{decimals}f}k"
+    else:
+        return f"{n:.{decimals}f}"
+
+
+# =============================================================================
+# LEGACY HELPER FUNCTIONS (backward compatibility)
+# =============================================================================
+# These functions work with the old unit_map format.
+# New code should use the functions above.
+
+
 def get_unit_converter(var_type: str, unit_mode: str):
-    """Return the converter function you already use."""
+    """Return the converter function (legacy interface).
+
+    DEPRECATED: Use get_converter() with UNIT_MAP instead.
+    """
     return unit_map[var_type][unit_mode]["func"]
 
 
 def get_hover_unit(var_type: str, unit_mode: str) -> str:
-    """Return the short unit string for hovers."""
+    """Return the short unit string for hovers (legacy interface).
+
+    DEPRECATED: Use get_display_unit() with UNIT_MAP instead.
+    """
     return unit_map[var_type][unit_mode]["hover_unit"]
 
 
 def get_unit_label(var_type: str, unit_mode: str) -> str:
-    """Return the short unit label (e.g., 'kW', 'm²')."""
+    """Return the short unit label (legacy interface).
+
+    DEPRECATED: Use get_display_unit() with UNIT_MAP instead.
+    """
     config = unit_map[var_type][unit_mode]
-    # Prefer 'short' if available, otherwise use 'hover_unit'
     return config.get("short", config.get("hover_unit", ""))
 
 
 def format_with_units(
     value, var_type: str, unit_mode: str, decimals: int = 1, include_unit: bool = True
 ) -> str:
-    """Format a value with appropriate unit conversion and label.
+    """Format a value with appropriate unit conversion and label (legacy interface).
+
+    DEPRECATED: Use format_value() + get_display_unit() instead.
 
     Args:
-        value: The raw value to format (in SI units)
+        value: The raw value to format (in base units)
         var_type: Type of variable (e.g., "power", "area", "temperature")
         unit_mode: "SI" or "IP"
         decimals: Number of decimal places (default: 1)
@@ -262,3 +792,72 @@ def format_with_units(
     except (KeyError, TypeError):
         # Fallback if var_type not in unit_map or conversion fails
         return str(value)
+
+
+def format_with_auto_scale(
+    value,
+    category: str,
+    unit_mode: str,
+    decimals: int = 1,
+    include_unit: bool = True,
+) -> str:
+    """Format a single value with automatic unit scaling.
+
+    Takes a value in base units and auto-scales to an appropriate display unit.
+
+    Args:
+        value: The raw value in BASE units (e.g., W, Wh, kg)
+        category: Unit category (e.g., "power", "energy", "emissions")
+        unit_mode: "SI" or "IP"
+        decimals: Number of decimal places (default: 1)
+        include_unit: Whether to append the unit label (default: True)
+
+    Returns:
+        Formatted string with auto-scaled value and optional unit label
+
+    Example:
+        >>> format_with_auto_scale(4500000, "power", "SI")
+        '4,500.0 kW'  # 4.5 MW shown as kW
+        >>> format_with_auto_scale(4500000, "power", "IP")
+        '15,356.3 kBTU/h'
+    """
+    if value is None:
+        return "—"
+
+    try:
+        # Determine auto-scaling directly from base unit value
+        scale, unit = get_auto_scale([value], category, unit_mode)
+        scaled = value / scale
+
+        formatted = f"{scaled:,.{decimals}f}"
+
+        if include_unit:
+            return f"{formatted} {unit}"
+        return formatted
+    except (KeyError, TypeError):
+        return str(value)
+
+
+def get_auto_scale_for_values(values, category: str, unit_mode: str):
+    """Pre-calculate auto-scale for a set of values in base units.
+
+    Useful when you need to apply consistent scaling across multiple values
+    (e.g., in a chart or table column).
+
+    Args:
+        values: Iterable of values in BASE units (W, Wh, kg, etc.)
+        category: Unit category
+        unit_mode: "SI" or "IP"
+
+    Returns:
+        Tuple of (scale_factor, unit_label) where:
+        - scale_factor: Divide base unit values by this to get display values
+        - unit_label: The unit string to display
+
+    Example:
+        >>> scale, unit = get_auto_scale_for_values([1500000, 800000], "power", "SI")
+        >>> print(scale, unit)  # 1000, "kW"
+        >>> display_values = [v / scale for v in values]  # [1500, 800]
+    """
+    scale, unit = get_auto_scale(values, category, unit_mode)
+    return scale, unit

--- a/utils/units.py
+++ b/utils/units.py
@@ -389,9 +389,8 @@ AUTO_SCALE_CONFIG = {
             (1e3, 1e3, "kW"),
         ],
         "IP": [
-            # 1 TR = 3517 W
-            (3517 * 1e3, 3517 * 1e3, "kTR"),  # >= 1000 TR
-            (3517, 3517, "TR"),               # >= 1 TR
+            # 1 TR = 3517 W - keep in TR only (no kTR)
+            (3517, 3517, "TR"),
         ],
     },
     "emissions": {

--- a/utils/units.py
+++ b/utils/units.py
@@ -83,6 +83,26 @@ def cop_hc_to_cop_h(cop_hc):
     return ((cop_hc - 1) / 2) + 1
 
 
+### UNIT CONVERSIONS FOR DISPLAY ###
+def W_to_kW(W):
+    return W / 1000
+
+
+def W_to_tons(W):
+    """Convert Watts to refrigeration tons."""
+    return W * W_to_ton
+
+
+def kW_to_tons(kW):
+    """Convert kilowatts to refrigeration tons."""
+    return kW * W_to_ton * 1000
+
+
+def sqm_to_sqft(sqm):
+    """Convert square meters to square feet."""
+    return sqm * 10.7639
+
+
 ### MAPPING FOR CHARTS ###
 unit_map = {
     "energy": {
@@ -133,6 +153,65 @@ unit_map = {
             "default_value": 0.15455 / (g_to_lb / Wh_to_BTU),  #! use function
         },
     },
+    "power": {
+        "SI": {
+            "func": W_to_kW,
+            "label": "Power (kW)",
+            "hover_unit": "kW",
+            "short": "kW",
+        },
+        "IP": {
+            "func": W_to_tons,
+            "label": "Power (tons)",
+            "hover_unit": "tons",
+            "short": "tons",
+        },
+    },
+    "area": {
+        "SI": {
+            "func": lambda x: x,
+            "label": "Area (m²)",
+            "hover_unit": "m²",
+            "short": "m²",
+        },
+        "IP": {
+            "func": sqm_to_sqft,
+            "label": "Area (ft²)",
+            "hover_unit": "ft²",
+            "short": "ft²",
+        },
+    },
+    "power_kw": {
+        # For data already in kW (e.g., load summaries)
+        "SI": {
+            "func": lambda x: x,
+            "label": "Power (kW)",
+            "hover_unit": "kW",
+            "short": "kW",
+        },
+        "IP": {
+            "func": kW_to_tons,
+            "label": "Power (tons)",
+            "hover_unit": "tons",
+            "short": "tons",
+        },
+    },
+    "ng_leakage_rate": {
+        # For NG leakage rate (stored in g/kWh)
+        "SI": {
+            "func": lambda x: x,
+            "label": "NG leakage (g/kWh)",
+            "hover_unit": "g/kWh",
+            "short": "g/kWh",
+        },
+        "IP": {
+            # Convert g/kWh to lb/kBTU: divide by 454 (g→lb), divide by 3.412 (kWh→kBTU)
+            "func": lambda x: x * g_to_lb / Wh_to_BTU,
+            "label": "NG leakage (lb/kBTU)",
+            "hover_unit": "lb/kBTU",
+            "short": "lb/kBTU",
+        },
+    },
 }
 
 
@@ -144,3 +223,42 @@ def get_unit_converter(var_type: str, unit_mode: str):
 def get_hover_unit(var_type: str, unit_mode: str) -> str:
     """Return the short unit string for hovers."""
     return unit_map[var_type][unit_mode]["hover_unit"]
+
+
+def get_unit_label(var_type: str, unit_mode: str) -> str:
+    """Return the short unit label (e.g., 'kW', 'm²')."""
+    config = unit_map[var_type][unit_mode]
+    # Prefer 'short' if available, otherwise use 'hover_unit'
+    return config.get("short", config.get("hover_unit", ""))
+
+
+def format_with_units(
+    value, var_type: str, unit_mode: str, decimals: int = 1, include_unit: bool = True
+) -> str:
+    """Format a value with appropriate unit conversion and label.
+
+    Args:
+        value: The raw value to format (in SI units)
+        var_type: Type of variable (e.g., "power", "area", "temperature")
+        unit_mode: "SI" or "IP"
+        decimals: Number of decimal places (default: 1)
+        include_unit: Whether to append the unit label (default: True)
+
+    Returns:
+        Formatted string with converted value and optional unit label
+    """
+    if value is None:
+        return "—"
+
+    try:
+        converter = get_unit_converter(var_type, unit_mode)
+        converted = converter(value)
+        formatted = f"{converted:,.{decimals}f}"
+
+        if include_unit:
+            unit_label = get_unit_label(var_type, unit_mode)
+            return f"{formatted} {unit_label}"
+        return formatted
+    except (KeyError, TypeError):
+        # Fallback if var_type not in unit_map or conversion fails
+        return str(value)


### PR DESCRIPTION
@praftery @urwahah 
This PR introduces a major upgrade by implementing a dynamic unit system that works with the unit toggle. Here’s what it does:

- **Global Unit Switching** – All tables, charts, modals, and other components now switch units consistently across the entire app.
- **Dynamic Scaling** – Units automatically scale up to the next tier (e.g., kW → MW) when values become high.

This was a huge lift, so there may still be some bugs. If you have time, please pull the latest development branch and run the app and help test. I tried to centralize all configs, so changing some units/tiers should not be a big deal from now on. Let's leave issue #78 open for now, I guess there'll be more discussions on units at some point anyway.

I also created and updated `unit-conventions.md` using AI to document all key unit decisions (based on our discussions). You can use this as a reference if you find yourself lost in the IP unit maze.  It's amazing how well it summarized all my changes 😄

💡 Additional updates:
- Data file downloads now include proper column headers with units, and they export in SI/IP based on the user’s setting at download start
- Added a small notification with a spinning wheel to indicate when a download is preparing

We can go over any questions or feedback next week. 👍🏼

T