### PR TITLE
Supply temp calcs #54

### DIFF
--- a/data/input/equipment_data.JSON
+++ b/data/input/equipment_data.JSON
@@ -14,11 +14,11 @@
         "heating": {
           "capacity_W": [323600, 647300, 704300, 818800, 933300, 1048100],
           "leaving_supply_t": {
-            "73.9": {
-              "cop": [2.28, 2.28, 2.3, 2.33, 2.35, 2.37]
-            },
             "32.2": {
               "cop": [6.7, 5.8, 5.9, 5.94, 5.97, 6.0]
+            },
+            "73.9": {
+              "cop": [2.28, 2.28, 2.3, 2.33, 2.35, 2.37]
             }
           },
           "constraints": {
@@ -689,12 +689,12 @@
       "eq_scen_id": "eq_scenario_1",
       "eq_scen_name": "Gas Boiler+AC Chiller",
       "hr_wwhp": null,
-      "hr_wwhp_h_supply_t": "32.2",
+      "hr_wwhp_h_supply_t": 32.2,
       "awhp": null,
       "awhp_sizing_mode": "integer_sizing_peak_load",
       "awhp_sizing_value": 1,
       "awhp_redundancy": 1,
-      "awhp_h_supply_t": "38",
+      "awhp_h_supply_t": 38,
       "awhp_use_cooling": false,
       "backup_heating": "bo02",
       "chiller": "ch03"
@@ -703,12 +703,12 @@
       "eq_scen_id": "eq_scenario_2",
       "eq_scen_name": "Elec Boiler+AC Chiller",
       "hr_wwhp": null,
-      "hr_wwhp_h_supply_t": "32.2",
+      "hr_wwhp_h_supply_t": 32.2,
       "awhp": null,
       "awhp_sizing_mode": "integer_sizing_peak_load",
       "awhp_sizing_value": 1,
       "awhp_redundancy": 1,
-      "awhp_h_supply_t": "38",
+      "awhp_h_supply_t": 38,
       "awhp_use_cooling": false,
       "backup_heating": "res01",
       "chiller": "ch03"
@@ -717,12 +717,12 @@
       "eq_scen_id": "eq_scenario_3",
       "eq_scen_name": "20% AWHP (H+C)+Gas Backup",
       "hr_wwhp": null,
-      "hr_wwhp_h_supply_t": "32.2",
+      "hr_wwhp_h_supply_t": 32.2,
       "awhp": "hp01",
       "awhp_sizing_mode": "integer_sizing_peak_load",
       "awhp_sizing_value": 0.2,
       "awhp_redundancy": 1,
-      "awhp_h_supply_t": "38",
+      "awhp_h_supply_t": 38,
       "awhp_use_cooling": true,
       "backup_heating": "bo02",
       "chiller": "ch03"
@@ -731,12 +731,12 @@
       "eq_scen_id": "eq_scenario_4",
       "eq_scen_name": "100% AWHP (H+C)+Elec Backup",
       "hr_wwhp": null,
-      "hr_wwhp_h_supply_t": "32.2",
+      "hr_wwhp_h_supply_t": 32.2,
       "awhp": "hp01",
       "awhp_sizing_mode": "integer_sizing_peak_load",
       "awhp_sizing_value": 1,
       "awhp_redundancy": 1,
-      "awhp_h_supply_t": "38",
+      "awhp_h_supply_t": 38,
       "awhp_use_cooling": true,
       "backup_heating": "res01",
       "chiller": "ch03"
@@ -745,12 +745,12 @@
       "eq_scen_id": "eq_scenario_5",
       "eq_scen_name": "HR WWHP+100% AWHP (H+C)+Elec Backup",
       "hr_wwhp": "hr01",
-      "hr_wwhp_h_supply_t": "32.2",
+      "hr_wwhp_h_supply_t": 32.2,
       "awhp": "hp01",
       "awhp_sizing_mode": "integer_sizing_peak_load",
       "awhp_sizing_value": 1,
       "awhp_redundancy": 1,
-      "awhp_h_supply_t": "38",
+      "awhp_h_supply_t": 38,
       "awhp_use_cooling": true,
       "backup_heating": "res01",
       "chiller": "ch03"

--- a/layout/input.py
+++ b/layout/input.py
@@ -810,37 +810,25 @@ def edit_equipment_modal():
                             clearable=True,
                             searchable=True,
                         ),
-                        dmc.Select(
-                            id="edit-hr-wwhp-h-supply-t-select",
+                        dmc.NumberInput(
+                            id="edit-hr-wwhp-h-supply-t-value",
                             label="HR HP Heating supply temperature",
-                            placeholder="None",
-                            data=[
-                                "32.2",
-                                "48.9",
-                                "60",
-                                "73.9",
-                            ],  # update to be filled by callback based on currently selected HP
-                            clearable=True,
-                            searchable=True,
+                            min = 32.2,
+                            max = 73.9,
+                            step = 1,
+                            # style={"flex": 1},
+                            # update to be filled by callback based on currently selected HP
+                            # currently set to values from default wwhp
                         ),
-                        dmc.Select(
-                            id="edit-awhp-h-supply-t-select",
+                        dmc.NumberInput(
+                            id="edit-awhp-h-supply-t-value",
                             label="AWHP Heating supply temperature",
-                            placeholder="None",
-                            data=[
-                                "35",
-                                "38",
-                                "38.9",
-                                "43.3",
-                                "45",
-                                "48.9",
-                                "50",
-                                "52",
-                                "54.4",
-                                "60",
-                            ],  # update to be filled by callback based on currently selected HP
-                            clearable=True,
-                            searchable=True,
+                            min = 38,
+                            max = 52,
+                            step = 1,
+                            # style={"flex": 1},
+                            # update to be filled by callback based on currently selected HP
+                            # currently set to values from default awhp
                         ),
                     ],
                 ),

--- a/pages/equipment_page.py
+++ b/pages/equipment_page.py
@@ -580,12 +580,10 @@ def reset_equipment(n_clicks, initial_data):
     Output("edit-scenario-name-input", "value"),
     Output("edit-hr-wwhp-select", "data"),
     Output("edit-hr-wwhp-select", "value"),
-    # Output("edit-hr-wwhp-h-supply-t-select", "data"), # added for autofill callback, not implemented
-    Output("edit-hr-wwhp-h-supply-t-select", "value"),
+    Output("edit-hr-wwhp-h-supply-t-value", "value"),
     Output("edit-awhp-select", "data"),
     Output("edit-awhp-select", "value"),
-    # Output("edit-awhp-h-supply-t-select", "data"), # added for autofill callback, not implemented
-    Output("edit-awhp-h-supply-t-select", "value"),
+    Output("edit-awhp-h-supply-t-value", "value"),
     Output("edit-awhp-sizing-mode", "value"),
     Output("edit-awhp-sizing-value", "value"),
     Output("edit-awhp-redundancy", "value"),
@@ -771,9 +769,9 @@ def open_edit_modal(edit_clicks, equipment_data):
     State("edit-scenario-id-input", "value"),
     State("edit-scenario-name-input", "value"),
     State("edit-hr-wwhp-select", "value"),
-    State("edit-hr-wwhp-h-supply-t-select", "value"),
+    State("edit-hr-wwhp-h-supply-t-value", "value"),
     State("edit-awhp-select", "value"),
-    State("edit-awhp-h-supply-t-select", "value"),
+    State("edit-awhp-h-supply-t-value", "value"),
     State("edit-awhp-sizing-mode", "value"),
     State("edit-awhp-sizing-value", "value"),
     State("edit-awhp-redundancy", "value"),
@@ -894,19 +892,6 @@ def _build_equipment_options(
     if include_none:
         options = [{"label": none_label, "value": "None"}] + options
     return options
-
-# added for autofill callback, not implemented
-# def _build_heating_supply_temp_options(
-#         equipment_list, eq_id, include_none=True, none_label="None"
-# ):
-#     eq = equipment_list.get(eq_id)
-#     perf = eq.get("performance")
-#     heating = perf.get("heating")
-#     temps_perf = heating.get("leaving_supply_t")
-#     options = [{"label": f"{i}°C", "value": i} for i in list(temps_perf.keys())]
-#     if include_none:
-#         options = [{"label": none_label, "value": "None"}] + options
-#     return options
 
 @callback(
     Output("edit-awhp-sizing-value", "step"),

--- a/src/energy.py
+++ b/src/energy.py
@@ -16,18 +16,16 @@ from utils.logging_config import get_logger
 logger = get_logger(__name__)
 
 
-def _heat_recovery_plr_curve(e: Equipment, supply_t: str) -> pd.DataFrame:
+def _heat_recovery_plr_curve(e: Equipment, performance: PerformanceCurves) -> pd.DataFrame:
     """Heat recovery COP vs part-load ratio (PLR)."""
     if (
         e.performance
         and e.performance_heating.capacity_W
-        and e.performance_heating.leaving_supply_t[supply_t].cop
+        and performance.cop
     ):
-        if len(e.performance_heating.capacity_W) == len(
-            e.performance_heating.leaving_supply_t[supply_t].cop
-        ):
+        if len(e.performance_heating.capacity_W) == len(performance.cop):
             cap = e.performance_heating.capacity_W
-            cop = e.performance_heating.leaving_supply_t[supply_t].cop
+            cop = performance.cop
             return pd.DataFrame({"cap": cap, "cop": cop})
         else:
             logger.error(
@@ -44,42 +42,58 @@ def _heat_recovery_plr_curve(e: Equipment, supply_t: str) -> pd.DataFrame:
             f"Equipment '{e.eq_id}' lacks heating capacity info (capacity_W or COP curve)."
         )
 
+def _heating_supply_temp_performance(e: Equipment, supply_t: float) -> PerformanceCurves:
+    """Heat pump performance data (COP, capacity, operating constraints) interpolated based on supply water temperature"""
+    interp_perf = PerformanceCurves()
 
-# function for interpolating performance based on HHWST, not implemented
-# def _heating_supply_temp_performance(e: Equipment, supply_t: str) -> PerformanceCurves:
-# result = {}
+    # extract list of supply temperatures
+    equip_supply_temps_str = list(e.performance_heating.leaving_supply_t.keys())
+    equip_supply_temps = np.array(equip_supply_temps_str, dtype="float")
 
-# equip_supply_temps_str = list(e.performance_heating.leaving_supply_t.keys())
-# equip_supply_temps = np.array(equip_supply_temps_str, dtype="float")
-# cops = [e.performance_heating.leaving_supply_t[t].cop for t in equip_supply_temps_str]
-# caps = [e.performance_heating.leaving_supply_t[t].capacity_W for t in equip_supply_temps_str]
-# constraints = {"min": [e.performance_heating.leaving_supply_t[t].constraints["min_temp_C"] for t in equip_supply_temps_str],
-#                "max": [e.performance_heating.leaving_supply_t[t].constraints["max_temp_C"] for t in equip_supply_temps_str]}
+    if (
+        supply_t < e.performance_heating.constraints["min_temp_C"]
+        or supply_t > e.performance_heating.constraints["max_temp_C"]
+        ):
+        logger.error(
+            f"Supply water temperature {supply_t} is outside the bounds of the provided performance data for equipment '{e.eq_id}'."
+        )
+        raise ValueError(
+            f"Supply water temperature {supply_t} is outside the bounds of the provided performance data for equipment '{e.eq_id}'."
+        )
+    else:
+        # extract performance data into separate lists
+        cops = [e.performance_heating.leaving_supply_t[t].cop for t in equip_supply_temps_str]
+        if e.eq_type == "heat_pump": # only COP needed for WWHPs
+            caps = [e.performance_heating.leaving_supply_t[t].capacity_W for t in equip_supply_temps_str]
+            constraints = {
+                "min": [e.performance_heating.leaving_supply_t[t].constraints["min_temp_C"] for t in equip_supply_temps_str],
+                "max": [e.performance_heating.leaving_supply_t[t].constraints["max_temp_C"] for t in equip_supply_temps_str]
+                }
 
-# add a logging error for input temp outside range of equipment data
-# result["constraints"] = {"min_temp_C": np.interp(supply_t, equip_supply_temps, constraints["min"]),
-#                           "max_temp_C": np.interp(supply_t, equip_supply_temps, constraints["max"])}
-# result["cop"] = [np.interp(supply_t, equip_supply_temps, x) for x in zip(*cops)]
-# result["capacity_W"] = [np.interp(supply_t, equip_supply_temps, x) for x in zip(*caps)]
+        # interpolate and store results
+        interp_perf.cop = [interp_vector(equip_supply_temps, x, supply_t) for x in zip(*cops)]  
+        if e.eq_type == "heat_pump":
+            interp_perf.capacity_W = [interp_vector(equip_supply_temps, x, supply_t) for x in zip(*caps)]
+            interp_perf.constraints = {
+                "min_temp_C": interp_vector(equip_supply_temps, constraints["min"], supply_t),
+                "max_temp_C": interp_vector(equip_supply_temps, constraints["max"], supply_t)
+                }
 
-# print(result)
-
+        return interp_perf
 
 def _per_unit_heating_capacity_W(
-    e: Equipment, t_out: np.ndarray, supply_t: str
+    e: Equipment, t_out: np.ndarray, performance: PerformanceCurves
 ) -> np.ndarray:
     """Per-unit thermal capacity [W] vs outdoor temperature."""
     if (
         e.performance
         and e.performance_heating.t_out_C
-        and e.performance_heating.leaving_supply_t[supply_t].capacity_W
+        and performance.capacity_W
     ):
-        if len(e.performance_heating.t_out_C) == len(
-            e.performance_heating.leaving_supply_t[supply_t].capacity_W
-        ):
+        if len(e.performance_heating.t_out_C) == len(performance.capacity_W):
             cap_h = interp_vector(
                 e.performance_heating.t_out_C,
-                e.performance_heating.leaving_supply_t[supply_t].capacity_W,
+                performance.capacity_W,
                 t_out,
             )
         else:
@@ -98,24 +112,22 @@ def _per_unit_heating_capacity_W(
         raise ValueError(
             f"Equipment '{e.eq_id}' has no heating capacity info (fixed value or t_out-based curve for capacity_W)."
         )
-    cap_h = _capacity_constraints(e, t_out, cap_h, True, supply_t)
+    cap_h = _capacity_constraints(e, t_out, cap_h, performance, "heating")
     return cap_h
 
 
-def _per_unit_heating_cop(e: Equipment, t_out: np.ndarray, supply_t: str) -> np.ndarray:
+def _per_unit_heating_cop(e: Equipment, t_out: np.ndarray, performance: PerformanceCurves) -> np.ndarray:
     """Per-unit COP vs outdoor temperature."""
     # If the device has a COP curve, use it
     if (
         e.performance
         and e.performance_heating.t_out_C
-        and e.performance_heating.leaving_supply_t[supply_t].cop
+        and performance.cop
     ):
-        if len(e.performance_heating.t_out_C) == len(
-            e.performance_heating.leaving_supply_t[supply_t].cop
-        ):
+        if len(e.performance_heating.t_out_C) == len(performance.cop):
             return interp_vector(
                 e.performance_heating.t_out_C,
-                e.performance_heating.leaving_supply_t[supply_t].cop,
+                performance.cop,
                 t_out,
             )
         else:
@@ -131,20 +143,18 @@ def _per_unit_heating_cop(e: Equipment, t_out: np.ndarray, supply_t: str) -> np.
 
 
 def _per_unit_cooling_capacity_W(
-    e: Equipment, t_out: np.ndarray, supply_t: str
+    e: Equipment, t_out: np.ndarray, performance: PerformanceCurves
 ) -> np.ndarray:
     """Per-unit thermal capacity [W] vs outdoor temperature."""
     if (
         e.performance
         and e.performance_cooling.t_out_C
-        and e.performance_cooling.leaving_supply_t[supply_t].capacity_W
+        and performance.capacity_W
     ):
-        if len(e.performance_cooling.t_out_C) == len(
-            e.performance_cooling.leaving_supply_t[supply_t].capacity_W
-        ):
+        if len(e.performance_cooling.t_out_C) == len(performance.capacity_W):
             cap_c = interp_vector(
                 e.performance_cooling.t_out_C,
-                e.performance_cooling.leaving_supply_t[supply_t].capacity_W,
+                performance.capacity_W,
                 t_out,
             )
         else:
@@ -165,24 +175,22 @@ def _per_unit_cooling_capacity_W(
         raise ValueError(
             f"Equipment '{e.eq_id}' has no cooling capacity info (fixed value or t_out-based curve for capacity_W)."
         )
-    cap_c = _capacity_constraints(e, t_out, cap_c, False, supply_t)
+    cap_c = _capacity_constraints(e, t_out, cap_c, performance, "cooling")
     return cap_c
 
 
-def _per_unit_cooling_cop(e: Equipment, t_out: np.ndarray, supply_t: str) -> np.ndarray:
+def _per_unit_cooling_cop(e: Equipment, t_out: np.ndarray, performance: PerformanceCurves) -> np.ndarray:
     """Per-unit COP vs outdoor temperature."""
     # If the device has a COP curve, use it
     if (
         e.performance
         and e.performance_cooling.t_out_C
-        and e.performance_cooling.leaving_supply_t[supply_t].cop
+        and performance.cop
     ):
-        if len(e.performance_cooling.t_out_C) == len(
-            e.performance_cooling.leaving_supply_t[supply_t].cop
-        ):
+        if len(e.performance_cooling.t_out_C) == len(performance.cop):
             return interp_vector(
                 e.performance_cooling.t_out_C,
-                e.performance_cooling.leaving_supply_t[supply_t].cop,
+                performance.cop,
                 t_out,
             )
         else:
@@ -211,44 +219,22 @@ def _constant_cooling_efficiency(e: Equipment) -> Optional[float]:
 
 
 def _capacity_constraints(
-    e: Equipment, t_out: np.ndarray, cap: np.ndarray, heating: bool, supply_t: str
+    e: Equipment, t_out: np.ndarray, cap: np.ndarray, performance: PerformanceCurves, load_type: str
 ) -> np.ndarray:
     """Per-unit thermal capacity [W] vs outdoor temperature, limited by OAT constraints."""
     temps = np.asarray(t_out, dtype=float)
-    if heating:
-        high_t = np.nonzero(
-            temps
-            > e.performance_heating.leaving_supply_t[supply_t].constraints["max_temp_C"]
-        )
-        low_t = np.nonzero(
-            temps
-            < e.performance_heating.leaving_supply_t[supply_t].constraints["min_temp_C"]
-        )
+    high_t = np.nonzero(temps > performance.constraints["max_temp_C"])
+    low_t = np.nonzero(temps < performance.constraints["min_temp_C"])
 
-        logger.debug(
-            f"{len(high_t[0])} hours above AWHP heating operating limit; "
-            f"{len(low_t[0])} hours below AWHP heating operating limit "
-        )
-
-    else:
-        high_t = np.nonzero(
-            temps
-            > e.performance_cooling.leaving_supply_t[supply_t].constraints["max_temp_C"]
-        )
-        low_t = np.nonzero(
-            temps
-            < e.performance_cooling.leaving_supply_t[supply_t].constraints["min_temp_C"]
-        )
-
-        logger.debug(
-            f"{len(high_t[0])} hours above AWHP cooling operating limit; "
-            f"{len(low_t[0])} hours below AWHP cooling operating limit "
-        )
-
-    np.put(
-        cap, high_t[0], [0]
-    )  # replace capacities where temps are outside the HP's operating bounds with 0
+    logger.debug(
+        f"{len(high_t[0])} hours above AWHP {load_type} operating limit; "
+        f"{len(low_t[0])} hours below AWHP {load_type} operating limit "
+    )
+    
+    # replace capacities where temps are outside the HP's operating bounds with 0
+    np.put(cap, high_t[0], [0])  
     np.put(cap, low_t[0], [0])
+
     return cap
 
 
@@ -336,9 +322,12 @@ def loads_to_site_energy(
         if scen.hr_wwhp:
             logger.debug(f"Phase 1: HR WWHP using equipment '{scen.hr_wwhp}'")
             hr_wwhp = library.get_equipment(scen.hr_wwhp)
-            hr_wwhp_supply_t = scen.hr_wwhp_h_supply_t
 
-            plr_curve = _heat_recovery_plr_curve(hr_wwhp, hr_wwhp_supply_t)
+            hr_wwhp_supply_t = 50 # scen.hr_wwhp_h_supply_t # ! this is now a number input
+            logger.debug(f"HR WWHP heating water supply temperature: {hr_wwhp_supply_t}°C") 
+            hr_wwhp_h_performance = _heating_supply_temp_performance(hr_wwhp, hr_wwhp_supply_t)
+            
+            plr_curve = _heat_recovery_plr_curve(hr_wwhp, hr_wwhp_h_performance)
             if plr_curve.empty:
                 raise ValueError(f"HR WWHP '{hr_wwhp.eq_id}' lacks a PLR curve.")
 
@@ -449,11 +438,12 @@ def loads_to_site_energy(
             logger.debug(f"Phase 2: AWHP Heating using equipment '{scen.awhp}'")
             awhp_h = library.get_equipment(scen.awhp)
 
-            awhp_h_supply_t = scen.awhp_h_supply_t
-            logger.debug(f"AWHP heating water supply temperature: {awhp_h_supply_t}°C")
+            awhp_h_supply_t = 45 # scen.awhp_h_supply_t # ! this is now a number input
+            logger.debug(f"AWHP heating water supply temperature: {awhp_h_supply_t}°C") 
+            awhp_h_performance = _heating_supply_temp_performance(awhp_h, awhp_h_supply_t)
 
-            awhp_cap_h = _per_unit_heating_capacity_W(awhp_h, temps, awhp_h_supply_t)
-            awhp_cop_h = _per_unit_heating_cop(awhp_h, temps, awhp_h_supply_t)
+            awhp_cap_h = _per_unit_heating_capacity_W(awhp_h, temps, awhp_h_performance)
+            awhp_cop_h = _per_unit_heating_cop(awhp_h, temps, awhp_h_performance)
             if np.isnan(awhp_cop_h).all():
                 raise ValueError(f"AWHP heating '{awhp_h.eq_id}' lacks a COP curve.")
 
@@ -472,15 +462,11 @@ def loads_to_site_energy(
 
             if (
                 awhp_h.performance
-                and awhp_h.performance_heating.leaving_supply_t[
-                    awhp_h_supply_t
-                ].capacity_W
+                and awhp_h_performance.capacity_W
             ):
                 cap_ref = interp_vector(
                     awhp_h.performance_heating.t_out_C,
-                    awhp_h.performance_heating.leaving_supply_t[
-                        awhp_h_supply_t
-                    ].capacity_W,
+                    awhp_h_performance.capacity_W,
                     np.array([ref_temp_C]),
                 )[0]
             elif getattr(awhp_h, "capacity_W", None):
@@ -541,9 +527,8 @@ def loads_to_site_energy(
                 f"units={awhp_num_h}, with {redundancy} redundant = {awhp_num_h_r} total"
             )
 
-            cap_total_h_W = (
-                awhp_cap_h * awhp_num_h
-            )  # capacity calculations use the original sizing number
+            # capacity calculations use the original sizing number
+            cap_total_h_W = awhp_cap_h * awhp_num_h 
             served_h_W = np.minimum(df[Col.HHW_REM_W.value].to_numpy(), cap_total_h_W)
             elec_h_Wh = served_h_W / awhp_cop_h
 
@@ -657,13 +642,13 @@ def loads_to_site_energy(
             awhp_c = library.get_equipment(scen.awhp)
 
             # we don't have any HPs with >1 CHWST, this can be edited later to match HHWST if needed
-            awhp_c_supply_t = list(awhp_c.performance_cooling.leaving_supply_t.keys())[
-                0
-            ]  # extract first value
+            # this extracts the first value and uses that performance data
+            awhp_c_supply_t = list(awhp_c.performance_cooling.leaving_supply_t.keys())[0] 
             # logger.debug(f"AWHP cooling water supply temperature: {awhp_c_supply_t}°C")
+            awhp_c_performance = awhp_c.performance_cooling.leaving_supply_t[awhp_c_supply_t]
 
-            awhp_cap_c = _per_unit_cooling_capacity_W(awhp_c, temps, awhp_c_supply_t)
-            awhp_cop_c = _per_unit_cooling_cop(awhp_c, temps, awhp_c_supply_t)
+            awhp_cap_c = _per_unit_cooling_capacity_W(awhp_c, temps, awhp_c_performance)
+            awhp_cop_c = _per_unit_cooling_cop(awhp_c, temps, awhp_c_performance)
             if np.isnan(awhp_cop_c).all():
                 raise ValueError(f"AWHP cooling '{awhp_c.eq_id}' lacks a COP curve.")
 

--- a/src/energy.py
+++ b/src/energy.py
@@ -16,13 +16,11 @@ from utils.logging_config import get_logger
 logger = get_logger(__name__)
 
 
-def _heat_recovery_plr_curve(e: Equipment, performance: PerformanceCurves) -> pd.DataFrame:
+def _heat_recovery_plr_curve(
+    e: Equipment, performance: PerformanceCurves
+) -> pd.DataFrame:
     """Heat recovery COP vs part-load ratio (PLR)."""
-    if (
-        e.performance
-        and e.performance_heating.capacity_W
-        and performance.cop
-    ):
+    if e.performance and e.performance_heating.capacity_W and performance.cop:
         if len(e.performance_heating.capacity_W) == len(performance.cop):
             cap = e.performance_heating.capacity_W
             cop = performance.cop
@@ -42,7 +40,10 @@ def _heat_recovery_plr_curve(e: Equipment, performance: PerformanceCurves) -> pd
             f"Equipment '{e.eq_id}' lacks heating capacity info (capacity_W or COP curve)."
         )
 
-def _heating_supply_temp_performance(e: Equipment, supply_t: float) -> PerformanceCurves:
+
+def _heating_supply_temp_performance(
+    e: Equipment, supply_t: float
+) -> PerformanceCurves:
     """Heat pump performance data (COP, capacity, operating constraints) interpolated based on supply water temperature"""
     interp_perf = PerformanceCurves()
 
@@ -53,7 +54,7 @@ def _heating_supply_temp_performance(e: Equipment, supply_t: float) -> Performan
     if (
         supply_t < e.performance_heating.constraints["min_temp_C"]
         or supply_t > e.performance_heating.constraints["max_temp_C"]
-        ):
+    ):
         logger.error(
             f"Supply water temperature {supply_t} is outside the bounds of the provided performance data for equipment '{e.eq_id}'."
         )
@@ -62,34 +63,51 @@ def _heating_supply_temp_performance(e: Equipment, supply_t: float) -> Performan
         )
     else:
         # extract performance data into separate lists
-        cops = [e.performance_heating.leaving_supply_t[t].cop for t in equip_supply_temps_str]
-        if e.eq_type == "heat_pump": # only COP needed for WWHPs
-            caps = [e.performance_heating.leaving_supply_t[t].capacity_W for t in equip_supply_temps_str]
+        cops = [
+            e.performance_heating.leaving_supply_t[t].cop
+            for t in equip_supply_temps_str
+        ]
+        if e.eq_type == "heat_pump":  # only COP needed for WWHPs
+            caps = [
+                e.performance_heating.leaving_supply_t[t].capacity_W
+                for t in equip_supply_temps_str
+            ]
             constraints = {
-                "min": [e.performance_heating.leaving_supply_t[t].constraints["min_temp_C"] for t in equip_supply_temps_str],
-                "max": [e.performance_heating.leaving_supply_t[t].constraints["max_temp_C"] for t in equip_supply_temps_str]
-                }
+                "min": [
+                    e.performance_heating.leaving_supply_t[t].constraints["min_temp_C"]
+                    for t in equip_supply_temps_str
+                ],
+                "max": [
+                    e.performance_heating.leaving_supply_t[t].constraints["max_temp_C"]
+                    for t in equip_supply_temps_str
+                ],
+            }
 
         # interpolate and store results
-        interp_perf.cop = [interp_vector(equip_supply_temps, x, supply_t) for x in zip(*cops)]  
+        interp_perf.cop = [
+            interp_vector(equip_supply_temps, x, supply_t) for x in zip(*cops)
+        ]
         if e.eq_type == "heat_pump":
-            interp_perf.capacity_W = [interp_vector(equip_supply_temps, x, supply_t) for x in zip(*caps)]
+            interp_perf.capacity_W = [
+                interp_vector(equip_supply_temps, x, supply_t) for x in zip(*caps)
+            ]
             interp_perf.constraints = {
-                "min_temp_C": interp_vector(equip_supply_temps, constraints["min"], supply_t),
-                "max_temp_C": interp_vector(equip_supply_temps, constraints["max"], supply_t)
-                }
+                "min_temp_C": interp_vector(
+                    equip_supply_temps, constraints["min"], supply_t
+                ),
+                "max_temp_C": interp_vector(
+                    equip_supply_temps, constraints["max"], supply_t
+                ),
+            }
 
         return interp_perf
+
 
 def _per_unit_heating_capacity_W(
     e: Equipment, t_out: np.ndarray, performance: PerformanceCurves
 ) -> np.ndarray:
     """Per-unit thermal capacity [W] vs outdoor temperature."""
-    if (
-        e.performance
-        and e.performance_heating.t_out_C
-        and performance.capacity_W
-    ):
+    if e.performance and e.performance_heating.t_out_C and performance.capacity_W:
         if len(e.performance_heating.t_out_C) == len(performance.capacity_W):
             cap_h = interp_vector(
                 e.performance_heating.t_out_C,
@@ -112,18 +130,16 @@ def _per_unit_heating_capacity_W(
         raise ValueError(
             f"Equipment '{e.eq_id}' has no heating capacity info (fixed value or t_out-based curve for capacity_W)."
         )
-    cap_h = _capacity_constraints(e, t_out, cap_h, performance, "heating")
+    cap_h = _capacity_constraints(t_out, cap_h, performance, "heating")
     return cap_h
 
 
-def _per_unit_heating_cop(e: Equipment, t_out: np.ndarray, performance: PerformanceCurves) -> np.ndarray:
+def _per_unit_heating_cop(
+    e: Equipment, t_out: np.ndarray, performance: PerformanceCurves
+) -> np.ndarray:
     """Per-unit COP vs outdoor temperature."""
     # If the device has a COP curve, use it
-    if (
-        e.performance
-        and e.performance_heating.t_out_C
-        and performance.cop
-    ):
+    if e.performance and e.performance_heating.t_out_C and performance.cop:
         if len(e.performance_heating.t_out_C) == len(performance.cop):
             return interp_vector(
                 e.performance_heating.t_out_C,
@@ -146,11 +162,7 @@ def _per_unit_cooling_capacity_W(
     e: Equipment, t_out: np.ndarray, performance: PerformanceCurves
 ) -> np.ndarray:
     """Per-unit thermal capacity [W] vs outdoor temperature."""
-    if (
-        e.performance
-        and e.performance_cooling.t_out_C
-        and performance.capacity_W
-    ):
+    if e.performance and e.performance_cooling.t_out_C and performance.capacity_W:
         if len(e.performance_cooling.t_out_C) == len(performance.capacity_W):
             cap_c = interp_vector(
                 e.performance_cooling.t_out_C,
@@ -175,18 +187,16 @@ def _per_unit_cooling_capacity_W(
         raise ValueError(
             f"Equipment '{e.eq_id}' has no cooling capacity info (fixed value or t_out-based curve for capacity_W)."
         )
-    cap_c = _capacity_constraints(e, t_out, cap_c, performance, "cooling")
+    cap_c = _capacity_constraints(t_out, cap_c, performance, "cooling")
     return cap_c
 
 
-def _per_unit_cooling_cop(e: Equipment, t_out: np.ndarray, performance: PerformanceCurves) -> np.ndarray:
+def _per_unit_cooling_cop(
+    e: Equipment, t_out: np.ndarray, performance: PerformanceCurves
+) -> np.ndarray:
     """Per-unit COP vs outdoor temperature."""
     # If the device has a COP curve, use it
-    if (
-        e.performance
-        and e.performance_cooling.t_out_C
-        and performance.cop
-    ):
+    if e.performance and e.performance_cooling.t_out_C and performance.cop:
         if len(e.performance_cooling.t_out_C) == len(performance.cop):
             return interp_vector(
                 e.performance_cooling.t_out_C,
@@ -219,7 +229,10 @@ def _constant_cooling_efficiency(e: Equipment) -> Optional[float]:
 
 
 def _capacity_constraints(
-    e: Equipment, t_out: np.ndarray, cap: np.ndarray, performance: PerformanceCurves, load_type: str
+    t_out: np.ndarray,
+    cap: np.ndarray,
+    performance: PerformanceCurves,
+    load_type: str,
 ) -> np.ndarray:
     """Per-unit thermal capacity [W] vs outdoor temperature, limited by OAT constraints."""
     temps = np.asarray(t_out, dtype=float)
@@ -230,9 +243,9 @@ def _capacity_constraints(
         f"{len(high_t[0])} hours above AWHP {load_type} operating limit; "
         f"{len(low_t[0])} hours below AWHP {load_type} operating limit "
     )
-    
+
     # replace capacities where temps are outside the HP's operating bounds with 0
-    np.put(cap, high_t[0], [0])  
+    np.put(cap, high_t[0], [0])
     np.put(cap, low_t[0], [0])
 
     return cap
@@ -323,10 +336,14 @@ def loads_to_site_energy(
             logger.debug(f"Phase 1: HR WWHP using equipment '{scen.hr_wwhp}'")
             hr_wwhp = library.get_equipment(scen.hr_wwhp)
 
-            hr_wwhp_supply_t = 50 # scen.hr_wwhp_h_supply_t # ! this is now a number input
-            logger.debug(f"HR WWHP heating water supply temperature: {hr_wwhp_supply_t}°C") 
-            hr_wwhp_h_performance = _heating_supply_temp_performance(hr_wwhp, hr_wwhp_supply_t)
-            
+            hr_wwhp_supply_t = scen.hr_wwhp_h_supply_t
+            logger.debug(
+                f"HR WWHP heating water supply temperature: {hr_wwhp_supply_t}°C"
+            )
+            hr_wwhp_h_performance = _heating_supply_temp_performance(
+                hr_wwhp, hr_wwhp_supply_t
+            )
+
             plr_curve = _heat_recovery_plr_curve(hr_wwhp, hr_wwhp_h_performance)
             if plr_curve.empty:
                 raise ValueError(f"HR WWHP '{hr_wwhp.eq_id}' lacks a PLR curve.")
@@ -438,9 +455,11 @@ def loads_to_site_energy(
             logger.debug(f"Phase 2: AWHP Heating using equipment '{scen.awhp}'")
             awhp_h = library.get_equipment(scen.awhp)
 
-            awhp_h_supply_t = 45 # scen.awhp_h_supply_t # ! this is now a number input
-            logger.debug(f"AWHP heating water supply temperature: {awhp_h_supply_t}°C") 
-            awhp_h_performance = _heating_supply_temp_performance(awhp_h, awhp_h_supply_t)
+            awhp_h_supply_t = scen.awhp_h_supply_t
+            logger.debug(f"AWHP heating water supply temperature: {awhp_h_supply_t}°C")
+            awhp_h_performance = _heating_supply_temp_performance(
+                awhp_h, awhp_h_supply_t
+            )
 
             awhp_cap_h = _per_unit_heating_capacity_W(awhp_h, temps, awhp_h_performance)
             awhp_cop_h = _per_unit_heating_cop(awhp_h, temps, awhp_h_performance)
@@ -460,10 +479,7 @@ def loads_to_site_energy(
 
             ref_temp_C = 0.0  # Conservative outdoor temperature for sizing
 
-            if (
-                awhp_h.performance
-                and awhp_h_performance.capacity_W
-            ):
+            if awhp_h.performance and awhp_h_performance.capacity_W:
                 cap_ref = interp_vector(
                     awhp_h.performance_heating.t_out_C,
                     awhp_h_performance.capacity_W,
@@ -528,7 +544,7 @@ def loads_to_site_energy(
             )
 
             # capacity calculations use the original sizing number
-            cap_total_h_W = awhp_cap_h * awhp_num_h 
+            cap_total_h_W = awhp_cap_h * awhp_num_h
             served_h_W = np.minimum(df[Col.HHW_REM_W.value].to_numpy(), cap_total_h_W)
             elec_h_Wh = served_h_W / awhp_cop_h
 
@@ -643,9 +659,13 @@ def loads_to_site_energy(
 
             # we don't have any HPs with >1 CHWST, this can be edited later to match HHWST if needed
             # this extracts the first value and uses that performance data
-            awhp_c_supply_t = list(awhp_c.performance_cooling.leaving_supply_t.keys())[0] 
+            awhp_c_supply_t = list(awhp_c.performance_cooling.leaving_supply_t.keys())[
+                0
+            ]
             # logger.debug(f"AWHP cooling water supply temperature: {awhp_c_supply_t}°C")
-            awhp_c_performance = awhp_c.performance_cooling.leaving_supply_t[awhp_c_supply_t]
+            awhp_c_performance = awhp_c.performance_cooling.leaving_supply_t[
+                awhp_c_supply_t
+            ]
 
             awhp_cap_c = _per_unit_cooling_capacity_W(awhp_c, temps, awhp_c_performance)
             awhp_cop_c = _per_unit_cooling_cop(awhp_c, temps, awhp_c_performance)

--- a/src/equipment.py
+++ b/src/equipment.py
@@ -78,9 +78,9 @@ class EquipmentScenario(BaseModel):
     eq_scen_id: str
     eq_scen_name: str
     hr_wwhp: Optional[str]
-    hr_wwhp_h_supply_t: Optional[str]
+    hr_wwhp_h_supply_t: Optional[float]
     awhp: Optional[str]
-    awhp_h_supply_t: Optional[str]
+    awhp_h_supply_t: Optional[float]
     awhp_sizing_mode: Optional[Literal["integer_sizing_peak_load", "fractional_sizing_peak_load", "fixed_num_units"]] = None
     awhp_sizing_value: float
     awhp_redundancy: int


### PR DESCRIPTION
per #54:
- added interpolation calculation for performance data (COP, capacity, constraints) based on an input supply temperature
- revised supply temperature input to a number value
  - note that this input still needs to be updated to autofill the min/max based on the currently selected HP

my thought now is to use the new input, to be added, for selecting between performance calculation types (fixed COP, database points, coefficient curves) to select for HHW reset as well. i'd like to discuss in the meeting!