### PR TITLE
HWST comparison scenario group #104

### DIFF
--- a/data/input/equipment_data.JSON
+++ b/data/input/equipment_data.JSON
@@ -918,6 +918,54 @@
       "awhp_use_cooling": true,
       "backup_heating": "res02",
       "chiller": "ch03"
+    },
+    {
+      "eq_scen_id": "eq_scenario_13",
+      "eq_scen_name": "100% AWHP (H+C, High HHWST)+Elec Backup",
+      "hr_wwhp": null,
+      "hr_wwhp_performance_model": "interpolate_HHWST",
+      "hr_wwhp_h_supply_t": 48.9,
+      "awhp": "hp01",
+      "awhp_performance_model": "interpolate_HHWST_fixed",
+      "awhp_sizing_mode": "integer_sizing_peak_load",
+      "awhp_sizing_value": 1,
+      "awhp_redundancy": 1,
+      "awhp_h_supply_t": 52,
+      "awhp_use_cooling": true,
+      "backup_heating": "res02",
+      "chiller": "ch03"
+    },
+    {
+      "eq_scen_id": "eq_scenario_14",
+      "eq_scen_name": "100% AWHP (H+C, Reset HHWST)+Elec Backup",
+      "hr_wwhp": null,
+      "hr_wwhp_performance_model": "interpolate_HHWST",
+      "hr_wwhp_h_supply_t": 48.9,
+      "awhp": "hp01",
+      "awhp_performance_model": "interpolate_HHWST_reset",
+      "awhp_sizing_mode": "integer_sizing_peak_load",
+      "awhp_sizing_value": 1,
+      "awhp_redundancy": 1,
+      "awhp_h_supply_t": 38,
+      "awhp_use_cooling": true,
+      "backup_heating": "res02",
+      "chiller": "ch03"
+    },
+    {
+      "eq_scen_id": "eq_scenario_15",
+      "eq_scen_name": "HR WWHP+100% AWHP (H+C, High HHWST)+Elec Backup",
+      "hr_wwhp": "hr03",
+      "hr_wwhp_performance_model": "interpolate_HHWST",
+      "hr_wwhp_h_supply_t": 60,
+      "awhp": "hp01",
+      "awhp_performance_model": "interpolate_HHWST_fixed",
+      "awhp_sizing_mode": "integer_sizing_peak_load",
+      "awhp_sizing_value": 1,
+      "awhp_redundancy": 1,
+      "awhp_h_supply_t": 52,
+      "awhp_use_cooling": true,
+      "backup_heating": "res02",
+      "chiller": "ch03"
     }
   ],
   "scenario_groups": [
@@ -935,6 +983,11 @@
       "group_id": "heat_recovery",
       "group_name": "Heat Recovery",
       "scenario_ids": ["eq_scenario_10", "eq_scenario_11", "eq_scenario_12", "eq_scenario_5"]
+    },
+    {
+      "group_id": "hhw_supply_temps",
+      "group_name": "HHW Supply Temps",
+      "scenario_ids": ["eq_scenario_4", "eq_scenario_13", "eq_scenario_14", "eq_scenario_5", "eq_scenario_15"]
     }
   ]
 }

--- a/data/input/equipment_data.JSON
+++ b/data/input/equipment_data.JSON
@@ -921,7 +921,7 @@
     },
     {
       "eq_scen_id": "eq_scenario_13",
-      "eq_scen_name": "100% AWHP (H+C, High HHWST)+Elec Backup",
+      "eq_scen_name": "High HHWST 100% AWHP (H+C)+Elec Backup",
       "hr_wwhp": null,
       "hr_wwhp_performance_model": "interpolate_HHWST",
       "hr_wwhp_h_supply_t": 48.9,
@@ -937,7 +937,7 @@
     },
     {
       "eq_scen_id": "eq_scenario_14",
-      "eq_scen_name": "100% AWHP (H+C, Reset HHWST)+Elec Backup",
+      "eq_scen_name": "Reset HHWST 100% AWHP (H+C, Reset HHWST)+Elec Backup",
       "hr_wwhp": null,
       "hr_wwhp_performance_model": "interpolate_HHWST",
       "hr_wwhp_h_supply_t": 48.9,
@@ -953,7 +953,7 @@
     },
     {
       "eq_scen_id": "eq_scenario_15",
-      "eq_scen_name": "HR WWHP+100% AWHP (H+C, High HHWST)+Elec Backup",
+      "eq_scen_name": "High HHWST HR WWHP+100% AWHP (H+C)+Elec Backup",
       "hr_wwhp": "hr03",
       "hr_wwhp_performance_model": "interpolate_HHWST",
       "hr_wwhp_h_supply_t": 60,


### PR DESCRIPTION
Added a new scenario group per #104:
1. Default 100% AWHP (low HHWST)
2. 100% AWHP with high HHWST
3. 100% AWHP with reset HHWST
4. Default HR WWHP + 100% AWHP (low HHWST for both)
5. HR WWHP + 100% AWHP with high HHWST for both