### PR TITLE
feat: add load scaling #119

### DIFF
--- a/layout/input.py
+++ b/layout/input.py
@@ -1487,6 +1487,61 @@ def build_completeness_modal():
     )
 
 
+def build_scale_load_modal():
+    """Modal for scaling/normalizing a library load profile."""
+    return dmc.Modal(
+        title="Scale Load Profile",
+        id="scale-load-modal",
+        size="lg",
+        centered=True,
+        withCloseButton=True,
+        children=[
+            dmc.Text(
+                "Scale the library load profile to match your building. "
+                "Every hourly heating and cooling load will be multiplied by the computed scale factor.",
+                size="sm",
+                c="dimmed",
+            ),
+            dmc.Space(h="md"),
+            html.Div(id="scale-reference-info"),
+            dmc.Space(h="md"),
+            dmc.Text("Scaling options", size="sm", fw=600),
+            dmc.Space(h="xs"),
+            dmc.SegmentedControl(
+                id="scale-method-select",
+                value="area",
+                data=[
+                    {"label": "Building Area", "value": "area"},
+                    {"label": "Peak Heating Load", "value": "peak_heating"},
+                    {"label": "Peak Cooling Load", "value": "peak_cooling"},
+                ],
+                fullWidth=True,
+                size="sm",
+            ),
+            dmc.Space(h="md"),
+            dmc.Text(id="scale-target-label", size="sm", fw=500),
+            dmc.NumberInput(
+                id="scale-target-value",
+                placeholder="Enter value",
+                min=0,
+                decimalScale=2,
+                mt=4,
+            ),
+            dmc.Space(h="sm"),
+            dmc.Text(id="scale-preview-text", c="blue", size="sm", fw=500),
+            dmc.Text(id="scale-error-text", c="red", size="sm"),
+            dmc.Group(
+                [
+                    dmc.Button("Cancel", id="scale-cancel-btn", variant="outline"),
+                    dmc.Button("Apply", id="scale-apply-btn", color="blue"),
+                ],
+                justify="flex-end",
+                mt="md",
+            ),
+        ],
+    )
+
+
 def build_completeness_summary(data_summary: dict, source_type: str = "measured") -> html.Div:
     """
     Build the summary content from StandardLoad.get_data_summary().

--- a/layout/output.py
+++ b/layout/output.py
@@ -27,7 +27,7 @@ def get_nested_value(obj, attr_path):
     return obj
 
 
-def make_metadata_card(metadata: Metadata, fields, title="", unit_mode="SI"):
+def make_metadata_card(metadata: Metadata, fields, title="", unit_mode="SI", starred_keys=None):
     """Build a card displaying metadata fields with optional unit conversion.
 
     Args:
@@ -37,7 +37,9 @@ def make_metadata_card(metadata: Metadata, fields, title="", unit_mode="SI"):
             - (key, label, var_type) for unit-aware fields (var_type: "power", "area", "temperature")
         title: Card title
         unit_mode: "SI" or "IP" for unit conversion
+        starred_keys: Set of field keys whose display values get a trailing " *"
     """
+    starred_keys = starred_keys or set()
     rows = []
     for field in fields:
         # Unpack field definition
@@ -53,15 +55,16 @@ def make_metadata_card(metadata: Metadata, fields, title="", unit_mode="SI"):
         if var_type and value is not None:
             # Apply unit conversion with auto-scaling (includes unit in output)
             display_value = format_with_auto_scale(value, var_type, unit_mode)
-            label = base_label
         else:
             display_value = str(value) if value is not None else "-"
-            label = base_label
+
+        if key in starred_keys:
+            display_value = display_value + "*"
 
         rows.append(
             dmc.Group(
                 [
-                    dmc.Text(label, fw=200),
+                    dmc.Text(base_label, fw=200),
                     dmc.Text(display_value, c="dimmed"),
                 ],
                 justify="space-between",
@@ -96,7 +99,7 @@ def building_characteristics_card(metadata: Metadata, unit_mode="SI"):
     )
 
 
-def load_characteristics_card(metadata: Metadata, unit_mode="SI"):
+def load_characteristics_card(metadata: Metadata, unit_mode="SI", is_scaled=False):
     load_fields = [
         ("load_data.load_type", "Load Type"),
         ("load_data.annual_heating_cooling_ratio", "Annual H/C Ratio"),
@@ -106,9 +109,14 @@ def load_characteristics_card(metadata: Metadata, unit_mode="SI"):
         ("load_data.median_temp", "Median Outdoor Temp.", "temperature"),
         ("load_data.min_temp", "Min. Outdoor Temp.", "temperature"),
     ]
+    starred = {"load_data.hhw_max_load", "load_data.chw_max_load"} if is_scaled else set()
 
     return make_metadata_card(
-        metadata, load_fields, title="Load Characteristics", unit_mode=unit_mode
+        metadata,
+        load_fields,
+        title="Load Characteristics",
+        unit_mode=unit_mode,
+        starred_keys=starred,
     )
 
 

--- a/layout/shell.py
+++ b/layout/shell.py
@@ -65,6 +65,7 @@ def build_shell(page_content):
         dcc.Store(id="selected-building-store", storage_type="session"),
         dcc.Store(id="load-summary-store", storage_type="session", data=None),
         dcc.Store(id="pending-load-data-store", storage_type="session", data=None),
+        dcc.Store(id="scale-info-store", storage_type="session", data=None),
         # Scenario group selections (persisted across page navigation)
         dcc.Store(id="equipment-scenario-group-store", storage_type="session", data="default"),
         dcc.Store(id="emission-scenario-group-store", storage_type="session", data="year"),

--- a/pages/emissions_page.py
+++ b/pages/emissions_page.py
@@ -309,12 +309,14 @@ def handle_emission_group_selection(group_id, metadata_data, selected_ids, store
             scen["year"] = default_year
             scen["emission_type"] = default_emission_type
             scen["ng_emission_rate_gCO2e_per_kWh"] = default_ng_emission_rate
-            pct_leakage = scen["annual_refrig_leakage_percent"]*100
+            pct_leakage = scen["annual_refrig_leakage_percent"] * 100
             scen["em_scen_name"] = f"{pct_leakage:.0f}% leakage"
         elif group_id == "emission_types":
             # Set emission type, reset others to defaults
             scen["emission_type"] = emission_types[idx % len(emission_types)]
-            scen["ng_emission_rate_gCO2e_per_kWh"] = ng_emission_rate_values[idx % len(ng_emission_rate_values)]
+            scen["ng_emission_rate_gCO2e_per_kWh"] = ng_emission_rate_values[
+                idx % len(ng_emission_rate_values)
+            ]
             scen["year"] = default_year
             scen["annual_refrig_leakage_percent"] = default_leakage
             scen["em_scen_name"] = scen["emission_type"]
@@ -977,6 +979,8 @@ def update_ng_rate_on_emission_type_change(emission_type, unit_mode):
         ng_emission_rate = EmissionScenarioDefaults.NG_EMISSION_RATE_G_KWH.value
 
     if unit_mode == "IP":
-        ng_emission_rate = format_value(ng_emission_rate, "ng_emission_rate_gCO2e_per_kWh", unit_mode, decimals=2)
+        ng_emission_rate = format_value(
+            ng_emission_rate, "ng_emission_rate_gCO2e_per_kWh", unit_mode, decimals=2
+        )
 
     return ng_emission_rate

--- a/pages/equipment_page.py
+++ b/pages/equipment_page.py
@@ -1179,6 +1179,7 @@ def update_sizing_priority(use_cooling, sizing_mode):
 
 # helper to build equipment options for Selects
 
+
 def _build_equipment_options(
     equipment_list, eq_type, unit_mode, include_none=False, none_label="None"
 ):

--- a/pages/loads_page.py
+++ b/pages/loads_page.py
@@ -16,6 +16,7 @@ from layout.input import (
     build_building_table,
     build_completeness_modal,
     build_completeness_summary,
+    build_scale_load_modal,
     get_load_index,  # slider min/max values in base SI units (lazy-loaded)
     modal_load_data_selection,
     select_load_type,
@@ -78,6 +79,28 @@ def layout():
                         select_load_type(),
                         modal_load_data_selection(buildings_df=get_buildings_df()),
                         build_completeness_modal(),
+                        build_scale_load_modal(),
+                        html.Div(
+                            style={"marginTop": "20px"},
+                            children=[
+                                dmc.Tooltip(
+                                    dmc.Button(
+                                        "Scale Loads",
+                                        id="open-scale-load-modal",
+                                        variant="outline",
+                                        color="blue",
+                                        size="sm",
+                                        n_clicks=0,
+                                        disabled=True,
+                                    ),
+                                    id="scale-load-btn-tooltip",
+                                    label="Select a load from the library first",
+                                    withArrow=True,
+                                    position="right",
+                                ),
+                            ],
+                        ),
+                        html.Div(id="scale-confirmation-alert", style={"marginTop": "8px"}),
                     ],
                     bg="gray.0",
                     radius="md",
@@ -252,6 +275,49 @@ def update_metadata(
     return metadata.model_dump()
 
 
+def _build_summary_payload(load_obj: "StandardLoad") -> dict:
+    """Build monthly_peaks + temp_bins summary payload from a StandardLoad."""
+    df = load_obj.df.sort_index()
+
+    monthly = df.copy()
+    monthly["month"] = monthly.index.month
+    peaks = monthly.groupby("month", observed=True)[["heating_W", "cooling_W"]].max().reset_index()
+    monthly_summary = [
+        {
+            "month": int(row["month"]),
+            "HHW_W": float(row["heating_W"]),
+            "CHW_W": float(row["cooling_W"]),
+        }
+        for _, row in peaks.iterrows()
+    ]
+
+    temp_df = df.copy()
+    bin_width = 5
+    half = bin_width / 2
+    t_min = temp_df["t_out_C"].min()
+    t_max = temp_df["t_out_C"].max()
+    center_start = np.floor(t_min / bin_width) * bin_width
+    center_end = np.ceil(t_max / bin_width) * bin_width
+    centers = np.arange(center_start, center_end + bin_width, bin_width)
+    bin_edges = np.arange(center_start - half, center_end + half + bin_width, bin_width)
+    temp_df["t_bin"] = pd.cut(
+        temp_df["t_out_C"], bins=bin_edges, labels=centers, include_lowest=True
+    )
+    bin_stats = (
+        temp_df.groupby("t_bin", observed=True)[["heating_W", "cooling_W"]].mean().reset_index()
+    )
+    temp_summary = [
+        {
+            "center": float(row["t_bin"]) if row["t_bin"] is not None else None,
+            "HHW_W": float(row["heating_W"]),
+            "CHW_W": float(row["cooling_W"]),
+        }
+        for _, row in bin_stats.iterrows()
+    ]
+
+    return {"monthly_peaks": monthly_summary, "temp_bins": temp_summary}
+
+
 @callback(
     [
         Output("selected-building-store", "data"),
@@ -262,6 +328,8 @@ def update_metadata(
         Output("data-completeness-modal", "opened"),
         Output("completeness-summary-content", "children"),
         Output("pending-load-data-store", "data"),
+        Output("scale-info-store", "data", allow_duplicate=True),
+        Output("scale-confirmation-alert", "children", allow_duplicate=True),
     ],
     Input("confirm-building-button", "n_clicks"),
     State("building-radio-group", "value"),
@@ -285,11 +353,12 @@ def confirm_selection(n_clicks, current_choice, metadata_data, session_data):
         None,
     )
     if building is None:
-        # 8 outputs
         return (
             no_update,
             no_update,
             metadata_data,
+            no_update,
+            no_update,
             no_update,
             no_update,
             no_update,
@@ -351,6 +420,9 @@ def confirm_selection(n_clicks, current_choice, metadata_data, session_data):
     if building.get("load_file_path"):
         metadata.custom_load_path = building["load_file_path"]
 
+    # Clear any previous scaling override so the fresh selection starts unscaled
+    metadata.session_load_path = None
+
     # ------------------------------------------------------------------
     # Load data once, save parquet path, and compute summary payload
     # ------------------------------------------------------------------
@@ -382,65 +454,11 @@ def confirm_selection(n_clicks, current_choice, metadata_data, session_data):
         load_data_path = str(path)
         logger.info(f"Using load dataset with ID {metadata.building_id}, saved to {path}")
 
-        # -------------------------
         # Build summary for charts
-        # -------------------------
         if not isinstance(df.index, pd.DatetimeIndex):
             raise ValueError("Expected DatetimeIndex in StandardLoad.df")
 
-        # Monthly peaks (HHW & CHW) - keep in base units (W)
-        monthly = df.copy()
-        monthly["month"] = monthly.index.month
-        peaks = (
-            monthly.groupby("month", observed=True)[["heating_W", "cooling_W"]].max().reset_index()
-        )
-
-        monthly_summary = [
-            {
-                "month": int(row["month"]),
-                "HHW_W": float(row["heating_W"]),
-                "CHW_W": float(row["cooling_W"]),
-            }
-            for _, row in peaks.iterrows()
-        ]
-
-        # Temp bins: centered 5°C bins
-        temp_df = df.copy()
-        bin_width = 5
-        half = bin_width / 2
-
-        t_min = temp_df["t_out_C"].min()
-        t_max = temp_df["t_out_C"].max()
-
-        center_start = np.floor(t_min / bin_width) * bin_width
-        center_end = np.ceil(t_max / bin_width) * bin_width
-        centers = np.arange(center_start, center_end + bin_width, bin_width)
-        bin_edges = np.arange(center_start - half, center_end + half + bin_width, bin_width)
-
-        temp_df["t_bin"] = pd.cut(
-            temp_df["t_out_C"],
-            bins=bin_edges,
-            labels=centers,
-            include_lowest=True,
-        )
-
-        bin_stats = (
-            temp_df.groupby("t_bin", observed=True)[["heating_W", "cooling_W"]].mean().reset_index()
-        )
-
-        temp_summary = [
-            {
-                "center": float(row["t_bin"]) if row["t_bin"] is not None else None,
-                "HHW_W": float(row["heating_W"]),
-                "CHW_W": float(row["cooling_W"]),
-            }
-            for _, row in bin_stats.iterrows()
-        ]
-
-        summary_payload = {
-            "monthly_peaks": monthly_summary,
-            "temp_bins": temp_summary,
-        }
+        summary_payload = _build_summary_payload(load_obj)
 
     except Exception as e:
         logger.error(
@@ -507,6 +525,8 @@ def confirm_selection(n_clicks, current_choice, metadata_data, session_data):
             True,  # data-completeness-modal opened
             completeness_content,  # completeness-summary-content
             pending_data,  # pending-load-data-store
+            no_update,  # scale-info-store
+            no_update,  # scale-confirmation-alert
         )
 
     # For simulated data, proceed directly
@@ -519,6 +539,8 @@ def confirm_selection(n_clicks, current_choice, metadata_data, session_data):
         False,  # Don't open completeness modal
         no_update,  # completeness-summary-content
         None,  # Clear pending data
+        None,  # Clear scale-info-store
+        [],  # Clear scale-confirmation-alert
     )
 
 
@@ -535,6 +557,8 @@ def confirm_selection(n_clicks, current_choice, metadata_data, session_data):
         Output("data-completeness-modal", "opened", allow_duplicate=True),
         Output("pending-load-data-store", "data", allow_duplicate=True),
         Output("custom-metadata-error", "children"),
+        Output("scale-info-store", "data", allow_duplicate=True),
+        Output("scale-confirmation-alert", "children", allow_duplicate=True),
     ],
     Input("completeness-confirm-btn", "n_clicks"),
     State("pending-load-data-store", "data"),
@@ -626,6 +650,8 @@ def handle_completeness_confirm(
         False,  # Close completeness modal
         None,  # Clear pending data
         "",  # Clear error message
+        None,  # Clear scale-info-store
+        [],  # Clear scale-confirmation-alert
     )
 
 
@@ -678,8 +704,9 @@ def toggle_custom_metadata_inputs(pending_data, unit_mode):
     Output("summary-selection-info", "children"),
     Input("metadata-store", "data"),
     Input("unit-toggle", "value"),
+    Input("scale-info-store", "data"),
 )
-def show_metadata(data, unit_mode):
+def show_metadata(data, unit_mode, scale_info):
     if not data:
         return "No metadata yet"
 
@@ -689,7 +716,7 @@ def show_metadata(data, unit_mode):
     return (
         building_characteristics_card(metadata, unit_mode=unit_mode),
         dmc.Space(h=10),
-        load_characteristics_card(metadata, unit_mode=unit_mode),
+        load_characteristics_card(metadata, unit_mode=unit_mode, is_scaled=bool(scale_info)),
     )
 
 
@@ -730,56 +757,7 @@ def parse_custom_load_data(contents, filename, session_id="default"):
         temp_file = folder / f"custom_load_{Path(filename).stem}.parquet"
         load_obj.to_parquet(temp_file)
 
-        # Build summary payload for charts (same logic as confirm_selection)
-        df_sorted = load_obj.df.sort_index()
-
-        # Monthly peaks
-        monthly = df_sorted.copy()
-        monthly["month"] = monthly.index.month
-        peaks = (
-            monthly.groupby("month", observed=True)[["heating_W", "cooling_W"]].max().reset_index()
-        )
-        monthly_summary = [
-            {
-                "month": int(row["month"]),
-                "HHW_W": float(row["heating_W"]),
-                "CHW_W": float(row["cooling_W"]),
-            }
-            for _, row in peaks.iterrows()
-        ]
-
-        # Temp bins
-        temp_df = df_sorted.copy()
-        bin_width = 5
-        half = bin_width / 2
-        t_min = temp_df["t_out_C"].min()
-        t_max = temp_df["t_out_C"].max()
-        center_start = np.floor(t_min / bin_width) * bin_width
-        center_end = np.ceil(t_max / bin_width) * bin_width
-        centers = np.arange(center_start, center_end + bin_width, bin_width)
-        bin_edges = np.arange(center_start - half, center_end + half + bin_width, bin_width)
-        temp_df["t_bin"] = pd.cut(
-            temp_df["t_out_C"],
-            bins=bin_edges,
-            labels=centers,
-            include_lowest=True,
-        )
-        bin_stats = (
-            temp_df.groupby("t_bin", observed=True)[["heating_W", "cooling_W"]].mean().reset_index()
-        )
-        temp_summary = [
-            {
-                "center": float(row["t_bin"]) if row["t_bin"] is not None else None,
-                "HHW_W": float(row["heating_W"]),
-                "CHW_W": float(row["cooling_W"]),
-            }
-            for _, row in bin_stats.iterrows()
-        ]
-
-        summary_payload = {
-            "monthly_peaks": monthly_summary,
-            "temp_bins": temp_summary,
-        }
+        summary_payload = _build_summary_payload(load_obj)
 
         # Compute load statistics for LoadData fields
         load_stats = load_obj.compute_load_stats()
@@ -1431,3 +1409,264 @@ def update_load_visualization(summary_data, pathname, unit_mode):
                 icon="ph:warning-circle",
             )
         ]
+
+
+# -------------------------------------------------------------------
+# Scale loads feature
+# -------------------------------------------------------------------
+
+
+@callback(
+    Output("open-scale-load-modal", "disabled"),
+    Output("scale-load-btn-tooltip", "disabled"),
+    Input("metadata-store", "data"),
+)
+def update_scale_btn_state(metadata_data):
+    """Disable the 'Scale Loads' button when no library load is selected."""
+    if not metadata_data:
+        return True, False
+    metadata = Metadata(**metadata_data)
+    if metadata.load_data.load_type not in ("simulated", "measured"):
+        return True, False
+    return False, True  # button enabled, tooltip hidden
+
+
+@callback(
+    Output("scale-load-modal", "opened", allow_duplicate=True),
+    Output("scale-reference-info", "children"),
+    Input("open-scale-load-modal", "n_clicks"),
+    Input("scale-cancel-btn", "n_clicks"),
+    State("metadata-store", "data"),
+    State("unit-toggle", "value"),
+    prevent_initial_call=True,
+)
+def toggle_scale_modal(open_clicks, cancel_clicks, metadata_data, unit_mode):
+    """Open or close the scale load modal."""
+    from utils.units import W_to_BTUh, W_to_kW, W_to_tons, sqm_to_sqft
+
+    if ctx.triggered_id == "scale-cancel-btn":
+        return False, no_update
+
+    if not metadata_data:
+        return False, no_update
+
+    unit_mode = unit_mode or "SI"
+    metadata = Metadata(**metadata_data)
+    ld = metadata.load_data
+
+    def _fmt(val, decimals=1):
+        return f"{val:,.{decimals}f}" if val is not None else "—"
+
+    if unit_mode == "IP":
+        area_val = sqm_to_sqft(metadata.area_sqm) if metadata.area_sqm else None
+        area_unit = "ft²"
+        hhw_val = ld.hhw_max_load * W_to_BTUh if ld.hhw_max_load is not None else None
+        hhw_unit = "BTU/h"
+        chw_val = W_to_tons(ld.chw_max_load) if ld.chw_max_load is not None else None
+        chw_unit = "TR"
+    else:
+        area_val = metadata.area_sqm
+        area_unit = "m²"
+        hhw_val = W_to_kW(ld.hhw_max_load) if ld.hhw_max_load is not None else None
+        hhw_unit = "kW"
+        chw_val = W_to_kW(ld.chw_max_load) if ld.chw_max_load is not None else None
+        chw_unit = "kW"
+
+    ref_info = dmc.Stack(
+        gap=4,
+        children=[
+            dmc.Text("Library building reference values:", size="sm", fw=600),
+            dmc.Text(f"Area: {_fmt(area_val, 0)} {area_unit}", size="sm"),
+            dmc.Text(f"Peak heating: {_fmt(hhw_val)} {hhw_unit}", size="sm"),
+            dmc.Text(f"Peak cooling: {_fmt(chw_val)} {chw_unit}", size="sm"),
+        ],
+    )
+
+    return True, ref_info
+
+
+@callback(
+    Output("scale-preview-text", "children"),
+    Output("scale-target-label", "children"),
+    Output("scale-error-text", "children"),
+    Input("scale-method-select", "value"),
+    Input("scale-target-value", "value"),
+    State("metadata-store", "data"),
+    State("unit-toggle", "value"),
+    prevent_initial_call=True,
+)
+def update_scale_preview(method, target_value, metadata_data, unit_mode):
+    """Update the input label and live scale-factor preview."""
+    from utils.units import BTUh_to_W, ton_to_W
+
+    unit_mode = unit_mode or "SI"
+
+    labels = {
+        "area": f"Your building area [{'ft²' if unit_mode == 'IP' else 'm²'}]",
+        "peak_heating": f"Your peak heating load [{'BTU/h' if unit_mode == 'IP' else 'kW'}]",
+        "peak_cooling": f"Your peak cooling load [{'TR' if unit_mode == 'IP' else 'kW'}]",
+    }
+    label = labels.get(method, "Enter value")
+
+    try:
+        target_value = float(target_value)
+    except (TypeError, ValueError):
+        return "", label, ""
+
+    if not metadata_data or target_value <= 0:
+        return "", label, ""
+
+    metadata = Metadata(**metadata_data)
+    ld = metadata.load_data
+
+    try:
+        if method == "area":
+            ref_si = metadata.area_sqm
+            target_si = target_value / 10.7639 if unit_mode == "IP" else target_value
+        elif method == "peak_heating":
+            ref_si = ld.hhw_max_load
+            target_si = target_value * BTUh_to_W if unit_mode == "IP" else target_value * 1000
+        else:  # peak_cooling
+            ref_si = ld.chw_max_load
+            target_si = target_value * ton_to_W if unit_mode == "IP" else target_value * 1000
+
+        if not ref_si or ref_si <= 0:
+            return "", label, f"Reference value for '{method}' not available in library data."
+
+        scale_factor = target_si / ref_si
+        if scale_factor <= 0:
+            return "", label, "Scale factor must be positive."
+
+        return f"Scale factor: {scale_factor:.3f}x", label, ""
+
+    except Exception as e:
+        return "", label, str(e)
+
+
+@callback(
+    Output("metadata-store", "data", allow_duplicate=True),
+    Output("load-summary-store", "data", allow_duplicate=True),
+    Output("scale-load-modal", "opened", allow_duplicate=True),
+    Output("scale-info-store", "data"),
+    Output("scale-confirmation-alert", "children"),
+    Input("scale-apply-btn", "n_clicks"),
+    State("scale-method-select", "value"),
+    State("scale-target-value", "value"),
+    State("metadata-store", "data"),
+    State("load-data-path-store", "data"),
+    State("unit-toggle", "value"),
+    prevent_initial_call=True,
+)
+def apply_scale(n_clicks, method, target_value, metadata_data, load_data_path, unit_mode):
+    """Apply load scaling: multiply every hourly heating_W and cooling_W by scale_factor."""
+    from utils.units import BTUh_to_W, W_to_BTUh, W_to_kW, W_to_tons, ton_to_W
+
+    no_change = (no_update, no_update, no_update, no_update, no_update)
+
+    if not n_clicks:
+        raise dash.exceptions.PreventUpdate
+
+    unit_mode = unit_mode or "SI"
+
+    if not metadata_data or not load_data_path:
+        return no_change
+
+    try:
+        target_value = float(target_value)
+    except (TypeError, ValueError):
+        return no_change
+
+    if target_value <= 0:
+        return no_change
+
+    metadata = Metadata(**metadata_data)
+    ld = metadata.load_data
+
+    # Compute scale factor
+    try:
+        if method == "area":
+            ref_si = metadata.area_sqm
+            target_si = target_value / 10.7639 if unit_mode == "IP" else target_value
+            method_label = "building area"
+        elif method == "peak_heating":
+            ref_si = ld.hhw_max_load
+            target_si = target_value * BTUh_to_W if unit_mode == "IP" else target_value * 1000
+            method_label = "peak heating load"
+        else:  # peak_cooling
+            ref_si = ld.chw_max_load
+            target_si = target_value * ton_to_W if unit_mode == "IP" else target_value * 1000
+            method_label = "peak cooling load"
+
+        if not ref_si or ref_si <= 0:
+            return no_change
+
+        scale_factor = target_si / ref_si
+        if scale_factor <= 0:
+            return no_change
+
+    except Exception as e:
+        logger.error(f"Scale factor computation failed: {e}")
+        return no_change
+
+    # Load, scale, and save parquet
+    try:
+        load_obj = StandardLoad.from_parquet(load_data_path)
+
+        orig_hhw_max = float(load_obj.df["heating_W"].max())
+        orig_chw_max = float(load_obj.df["cooling_W"].max())
+
+        scaled_df = load_obj.df.copy()
+        scaled_df["heating_W"] = scaled_df["heating_W"] * scale_factor
+        scaled_df["cooling_W"] = scaled_df["cooling_W"] * scale_factor
+        scaled_load = StandardLoad(scaled_df.reset_index())
+        scaled_load.to_parquet(load_data_path)
+
+    except Exception as e:
+        logger.error(f"Error scaling load data: {e}")
+        return no_change
+
+    # Recompute stats and update metadata
+    new_stats = scaled_load.compute_load_stats()
+    if method == "area":
+        metadata.area_sqm = target_si
+    metadata.load_data = LoadData.model_validate({**ld.model_dump(), **new_stats})
+    metadata.session_load_path = load_data_path
+
+    # Rebuild summary payload for charts
+    summary_payload = _build_summary_payload(scaled_load)
+
+    # Build confirmation alert
+    def _display_power(w_val):
+        if w_val is None:
+            return "—"
+        if unit_mode == "IP":
+            if method == "peak_cooling":
+                return f"{W_to_tons(w_val):.1f} TR"
+            return f"{w_val * W_to_BTUh:,.0f} BTU/h"
+        return f"{W_to_kW(w_val):.1f} kW"
+
+    new_hhw = new_stats["hhw_max_load"]
+    new_chw = new_stats["chw_max_load"]
+
+    alert = dmc.Alert(
+        title=f"Load scaled* by {scale_factor:.3f}x",
+        color="blue",
+        variant="light",
+        withCloseButton=True,
+        children=dmc.Text(f"(based on {method_label})", size="sm", fw=400),
+    )
+
+    scale_info = {
+        "method": method_label,
+        "scale_factor": round(scale_factor, 6),
+        "orig_hhw_max_W": orig_hhw_max,
+        "orig_chw_max_W": orig_chw_max,
+        "new_hhw_max_W": new_hhw,
+        "new_chw_max_W": new_chw,
+    }
+
+    logger.info(
+        f"Applied load scale factor {scale_factor:.4f} (method={method_label}) to {load_data_path}"
+    )
+
+    return metadata.model_dump(), summary_payload, False, scale_info, alert

--- a/src/energy.py
+++ b/src/energy.py
@@ -176,8 +176,10 @@ def _equipment_data_validation(library: EquipmentLibrary, scenario_ids: list[str
                 awhp_c = library.get_equipment(scen.awhp)
 
                 if scen.awhp_sizing_priority is None:
-                    raise ValueError(f"AWHP scenario '{scen.eq_scen_id}' requires 'awhp_sizing_priority'.")
-                
+                    raise ValueError(
+                        f"AWHP scenario '{scen.eq_scen_id}' requires 'awhp_sizing_priority'."
+                    )
+
                 if not awhp_c.performance_cooling:
                     raise ValueError(f"Equipment '{awhp_c.eq_id}' lacks cooling performance data.")
 
@@ -437,6 +439,7 @@ def _capacity_constraints(
 
     return cap
 
+
 def _awhp_reference_capacity(
     e: Equipment,
     performance: PerformanceCurves,
@@ -462,10 +465,8 @@ def _awhp_reference_capacity(
             ref_temp_C = 30.0  # Conservative outdoor temperature for sizing
             ref_supply_temp = supply_t
 
-        ref_capacity_W = e.performance[load_type].leaving_supply_t[
-            ref_supply_temp
-        ].capacity_W
-        
+        ref_capacity_W = e.performance[load_type].leaving_supply_t[ref_supply_temp].capacity_W
+
         cap_ref = interp_vector(
             e.performance[load_type].t_out_C,
             ref_capacity_W,
@@ -711,29 +712,36 @@ def loads_to_site_energy(
             # Determine reference capacity
             if sizing_priority == "heating":
                 sizing_load = "hhw_W"
-                cap_ref = _awhp_reference_capacity(awhp_h, awhp_h_performance, awhp_h_supply_t, "heating")
-                
+                cap_ref = _awhp_reference_capacity(
+                    awhp_h, awhp_h_performance, awhp_h_supply_t, "heating"
+                )
+
             elif sizing_priority == "cooling":
                 sizing_load = "chw_W"
-                cap_ref = _awhp_reference_capacity(awhp_c, awhp_c_performance, awhp_c_supply_t, "cooling")
-            
+                cap_ref = _awhp_reference_capacity(
+                    awhp_c, awhp_c_performance, awhp_c_supply_t, "cooling"
+                )
+
             elif sizing_priority == "larger" and sizing_mode in [
                 "integer_sizing_peak_load",
                 "fractional_sizing_peak_load",
             ]:
                 cap_ref = {
-                    "hhw_W": _awhp_reference_capacity(awhp_h, awhp_h_performance, awhp_h_supply_t, "heating"),
-                    "chw_W": _awhp_reference_capacity(awhp_c, awhp_c_performance, awhp_c_supply_t, "cooling")
+                    "hhw_W": _awhp_reference_capacity(
+                        awhp_h, awhp_h_performance, awhp_h_supply_t, "heating"
+                    ),
+                    "chw_W": _awhp_reference_capacity(
+                        awhp_c, awhp_c_performance, awhp_c_supply_t, "cooling"
+                    ),
                 }
                 num = {
                     "hhw_W": float(df["hhw_W"].max()) * sizing_value / cap_ref["hhw_W"],
-                    "chw_W": float(df["chw_W"].max()) * sizing_value / cap_ref["chw_W"]
+                    "chw_W": float(df["chw_W"].max()) * sizing_value / cap_ref["chw_W"],
                 }
-                sizing_load = max(num, key = num.get)
+                sizing_load = max(num, key=num.get)
                 cap_ref = cap_ref[sizing_load]
 
                 logger.debug(f"{sizing_load} drives AWHP sizing.")
-
 
             # Determine number of units
             if sizing_mode in [
@@ -901,17 +909,17 @@ def loads_to_site_energy(
             awhp_turndown = 0.5
             num_compressors = awhp_num / awhp_turndown
             # calculate number of "compressors" used to serve heating load
-            num_compressors_h = np.maximum(0,
-                                    np.ceil(
-                                        num_compressors
-                                        * df[Col.AWHP_HHW_W.value] 
-                                        / df[Col.AWHP_CAP_H_W.value]
-                                    )
-                                )
-            num_compressors_h[np.isnan(num_compressors_h)] = 0 # for hours where AWHP heating capacity is 0
+            num_compressors_h = np.maximum(
+                0, np.ceil(num_compressors * df[Col.AWHP_HHW_W.value] / df[Col.AWHP_CAP_H_W.value])
+            )
+            num_compressors_h[np.isnan(num_compressors_h)] = (
+                0  # for hours where AWHP heating capacity is 0
+            )
             # remaining compressors can serve cooling load
             num_compressors_c = np.maximum(0, num_compressors - num_compressors_h)
-            awhp_num_c = num_compressors_c * awhp_turndown # number of compressors available to operate in cooling
+            awhp_num_c = (
+                num_compressors_c * awhp_turndown
+            )  # number of compressors available to operate in cooling
 
             cap_total_c_W = awhp_cap_c * awhp_num_c
             served_c_W = np.minimum(df[Col.CHW_REM_W.value].to_numpy(), cap_total_c_W)

--- a/src/equipment.py
+++ b/src/equipment.py
@@ -11,6 +11,7 @@ from src.mixins import DotAccessMixin
 # --- Models ---
 class PerformanceCurves(BaseModel):
     """Equipment performance curves: coefficient of performance (COP), capacity, and outdoor air temperature constraints."""
+
     cop: list[float] | None = None
     capacity_W: list[float] | None = None
     constraints: dict[str, float] | None = None
@@ -21,7 +22,8 @@ class Performance(BaseModel):
     Leaving supply water temperatures, associated performance curves, and supply water temperature constraints.
     Outdoor air temperature curve for AWHPs, capacity curve for WWHPs, constant efficiency for boilers/chillers.
     """
-    t_out_C: list[float] | None = None 
+
+    t_out_C: list[float] | None = None
     capacity_W: list[float] | None = None
     leaving_supply_t: dict[str, PerformanceCurves] | None = None
     efficiency: float | None = None
@@ -29,20 +31,26 @@ class Performance(BaseModel):
 
 
 class Emissions(BaseModel):
-    """"Equipment emissions data."""
+    """ "Equipment emissions data."""
+
     co2_kg_per_mwh: float
+
 
 class Dimensions(BaseModel):
     """Equipment physical dimensions in metres."""
+
     length: float | None = None
     height: float | None = None
     width: float | None = None
 
+
 class Electrical(BaseModel):
     """Equipment electrical characteristics: minimum circuit amperage (MCA), voltage, and phase."""
+
     mca: float | None = None
     voltage: float | None = None
     phase: int | None = None
+
 
 class Equipment(BaseModel):
     eq_id: str
@@ -95,9 +103,7 @@ class EquipmentScenario(DotAccessMixin, BaseModel):
     awhp_sizing_value: float
     awhp_redundancy: int
     awhp_use_cooling: bool
-    awhp_sizing_priority: (
-        Literal["heating", "cooling", "larger"] | None
-    ) = None
+    awhp_sizing_priority: Literal["heating", "cooling", "larger"] | None = None
     backup_heating: str | None = None
     chiller: str | None = None
 

--- a/src/loads.py
+++ b/src/loads.py
@@ -271,7 +271,12 @@ def get_load_data(metadata: Metadata) -> StandardLoad:
 
     - simulated / measured: from a single parquet, filtered by building_id + load_type
     - custom: from user-uploaded csv at metadata.custom_load_path
+    - session_load_path takes priority over all of the above (e.g. after scaling)
     """
+    if metadata.session_load_path:
+        logger.info(f"Loading session load from {metadata.session_load_path}")
+        return StandardLoad.from_parquet(metadata.session_load_path)
+
     load_type = metadata.load_data.load_type
 
     if load_type in ("simulated", "measured"):

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -64,6 +64,7 @@ class Metadata(DotAccessMixin, BaseModel):
     units: str
     last_updated: str
     custom_load_path: str | None = None  # Path to custom load data file if load_type='load_custom'
+    session_load_path: str | None = None  # Overrides central parquet when set (e.g. after scaling)
 
     @property
     def base_gea_grid_region(self) -> str | None:

--- a/utils/display_registry.py
+++ b/utils/display_registry.py
@@ -28,11 +28,10 @@ class DisplayRegistry:
     def _build_equipment_lookup(cls):
         """Build the equipment ID to manufacturer+model name lookup dictionary."""
         library = load_library("data/input/equipment_data.JSON")
-        cls._equipment_lookup = {eq.eq_id:
-                                    eq.model if eq.eq_manufacturer is None
-                                    else f"{eq.eq_manufacturer} {eq.model}" 
-                                    for eq in library.equipment
-                                }
+        cls._equipment_lookup = {
+            eq.eq_id: eq.model if eq.eq_manufacturer is None else f"{eq.eq_manufacturer} {eq.model}"
+            for eq in library.equipment
+        }
 
     @classmethod
     def clear_cache(cls):


### PR DESCRIPTION
**Load scaling / normalization for library buildings**

Users can now easily scale a library load profile to better fit their project, without needing any measured or simulated building data. Once you pick a library load, a “Scale Loads” button becomes active in the left panel. On clicking, there'll be a pop-up where you can pick how you want to normalize, like by building area, peak heating load, or peak cooling load, type in your target value, and see the scale factor before you apply it.

<img width="1322" height="698" alt="Screenshot 2026-08-05 at 6 24 08 PM" src="https://github.com/user-attachments/assets/b7aaf1c4-0487-4e39-a6ce-a5a6a4a13bb0" />

When you hit apply, all the hourly heating and cooling numbers in the load profile get multiplied by that scale factor. The load card updates right away and shows the new peak values with a little asterisk (*, to highlight that the load has been scaled), plus you’ll get a small message telling you the scale factor that was applied. That scaled profile is then used for all later energy and emissions calculations.

<img width="641" height="486" alt="Screenshot 2026-08-05 at 6 24 37 PM" src="https://github.com/user-attachments/assets/78e02a6f-c6eb-4815-9a13-a02447dadb5b" />

<img width="1326" height="682" alt="Screenshot 2026-08-05 at 6 25 19 PM" src="https://github.com/user-attachments/assets/c46e9763-d7a6-4454-bd65-db417a228533" />

If you haven’t picked a library load yet, the button stays grayed out with a tooltip. And whenever you choose a new building, any scaling you’ve done automatically resets.

Feel free to check it out before I merge it into `development`. Obviously, we can make adjustments (e.g. UI etc.) down the line. But the key feature is mostly implemented. ✌🏼